### PR TITLE
Make decoder memory and pixel limits configurable

### DIFF
--- a/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
@@ -1,7 +1,15 @@
 package dev.keiji.jp2k
 
+const val DEFAULT_MAX_HEAP_SIZE_BYTES = 512L * 1024 * 1024
+
+// 256MB: Sufficient to return the decoded pixel data (e.g. 4000x3000 * 4 bytes/pixel ~= 48MB) plus overhead as a Hex string or byte array.
+const val DEFAULT_MAX_EVALUATION_RETURN_SIZE_BYTES = 256 * 1024 * 1024
+
+const val DEFAULT_MAX_PIXELS = 16000000
+
 internal const val ASSET_PATH_WASM = "openjpeg_core.wasm"
-internal const val MAX_PIXELS = 16000000
+
+// 512MB: Sufficient to decode large high-resolution images (e.g. 4000x3000) which may require significant internal buffer space.
 internal const val MAX_INPUT_SIZE = 128 * 1024 * 1024 // 128MB
 internal const val MIN_INPUT_SIZE = 12 // JP2 signature box length
 

--- a/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
@@ -1,5 +1,6 @@
 package dev.keiji.jp2k
 
+// 512MB: Sufficient to decode large high-resolution images (e.g. 4000x3000) which may require significant internal buffer space.
 const val DEFAULT_MAX_HEAP_SIZE_BYTES = 512L * 1024 * 1024
 
 // 256MB: Sufficient to return the decoded pixel data (e.g. 4000x3000 * 4 bytes/pixel ~= 48MB) plus overhead as a Hex string or byte array.
@@ -9,7 +10,6 @@ const val DEFAULT_MAX_PIXELS = 16000000
 
 internal const val ASSET_PATH_WASM = "openjpeg_core.wasm"
 
-// 512MB: Sufficient to decode large high-resolution images (e.g. 4000x3000) which may require significant internal buffer space.
 internal const val MAX_INPUT_SIZE = 128 * 1024 * 1024 // 128MB
 internal const val MIN_INPUT_SIZE = 12 // JP2 signature box length
 

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kSandbox.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kSandbox.kt
@@ -9,36 +9,40 @@ import com.google.common.util.concurrent.ListenableFuture
 import java.util.concurrent.Executor
 
 object Jp2kSandbox {
-    // 512MB: Sufficient to decode large high-resolution images (e.g. 4000x3000) which may require significant internal buffer space.
-    private const val MAX_HEAP_SIZE_BYTES = 512L * 1024 * 1024
-
-    // 256MB: Sufficient to return the decoded pixel data (e.g. 4000x3000 * 4 bytes/pixel ~= 48MB) plus overhead as a Hex string or byte array.
-    private const val MAX_EVALUATION_RETURN_SIZE_BYTES = 256 * 1024 * 1024
-
     private var sandboxFuture: ListenableFuture<JavaScriptSandbox>? = null
     private val lock = Any()
 
     fun get(context: Context): ListenableFuture<JavaScriptSandbox> {
         synchronized(lock) {
             if (sandboxFuture == null) {
-                sandboxFuture = JavaScriptSandbox.createConnectedInstanceAsync(context.applicationContext)
+                sandboxFuture =
+                    JavaScriptSandbox.createConnectedInstanceAsync(context.applicationContext)
             }
             return sandboxFuture!!
         }
     }
 
-    fun createIsolate(sandbox: JavaScriptSandbox): JavaScriptIsolate {
+    fun createIsolate(
+        sandbox: JavaScriptSandbox,
+        maxHeapSizeBytes: Long,
+        maxEvaluationReturnSizeBytes: Int,
+    ): JavaScriptIsolate {
         val params = IsolateStartupParameters()
         if (sandbox.isFeatureSupported(JavaScriptSandbox.JS_FEATURE_ISOLATE_MAX_HEAP_SIZE)) {
-            params.maxHeapSizeBytes = MAX_HEAP_SIZE_BYTES
+            params.maxHeapSizeBytes = maxHeapSizeBytes
         }
         if (sandbox.isFeatureSupported(JavaScriptSandbox.JS_FEATURE_EVALUATE_WITHOUT_TRANSACTION_LIMIT)) {
-            params.maxEvaluationReturnSizeBytes = MAX_EVALUATION_RETURN_SIZE_BYTES
+            params.maxEvaluationReturnSizeBytes = maxEvaluationReturnSizeBytes
         }
         return sandbox.createIsolate(params)
     }
 
-    fun setupConsoleCallback(isolate: JavaScriptIsolate, sandbox: JavaScriptSandbox, executor: Executor, tag: String) {
+    fun setupConsoleCallback(
+        isolate: JavaScriptIsolate,
+        sandbox: JavaScriptSandbox,
+        executor: Executor,
+        tag: String
+    ) {
         if (sandbox.isFeatureSupported(JavaScriptSandbox.JS_FEATURE_CONSOLE_MESSAGING)) {
             isolate.setConsoleCallback(executor) { consoleMessage ->
                 Log.v(tag, consoleMessage.message)


### PR DESCRIPTION
- Extract default constants for heap size, return size, and max pixels to `Constants.kt`.
- Update `Jp2kDecoder` and `Jp2kDecoderAsync` constructors to accept optional configuration parameters (`maxPixels`, `maxHeapSizeBytes`, `maxEvaluationReturnSizeBytes`).
- Update `Jp2kSandbox.createIsolate` to accept memory limit parameters dynamically.
- Pass configured limits to the underlying JS isolate and decoder script.