### PR TITLE
Refactor Jp2kDecoder and update build config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -27,8 +28,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     buildFeatures {
         compose = true

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.kotlin.android) apply false
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -36,3 +36,4 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/android/lib/build.gradle.kts
+++ b/android/lib/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.dokka)
 }
 
@@ -24,14 +25,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-}
-
-dokka {
-    dokkaSourceSets.register("main") {
-        sourceRoots.from(file("src/main/java"))
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 }
 

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -2,17 +2,9 @@ package dev.keiji.jp2k
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.util.Log
-import androidx.core.content.ContextCompat
-import androidx.javascriptengine.JavaScriptIsolate
 import kotlinx.coroutines.suspendCancellableCoroutine
-import org.json.JSONObject
-import java.util.concurrent.Executor
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 /**
  * JPEG 2000 Decoder class using WebAssembly via Android JavaScriptEngine.
@@ -25,19 +17,9 @@ import kotlinx.coroutines.withContext
  */
 class Jp2kDecoder(
     context: Context,
-    private val config: Config = Config()
+    config: Config = Config(),
 ) {
-    private val assetManager = context.assets
-    private val sandboxFuture = Jp2kSandbox.get(context)
-    private val mainExecutor: Executor = ContextCompat.getMainExecutor(context)
-
-    private var jsIsolate: JavaScriptIsolate? = null
-
-    private fun log(priority: Int, message: String) {
-        if (config.logLevel != null && priority >= config.logLevel) {
-            Log.println(priority, TAG, message)
-        }
-    }
+    private val jp2kDecoderAsync = Jp2kDecoderAsync(context, config = config)
 
     /**
      * Initializes the decoder.
@@ -47,68 +29,16 @@ class Jp2kDecoder(
      *
      * @throws Exception If initialization fails.
      */
-    suspend fun init() {
-        val start = System.currentTimeMillis()
-        try {
-            suspendCancellableCoroutine { continuation ->
-                sandboxFuture.addListener({
-                    try {
-                        val sandbox = sandboxFuture.get()
-                        jsIsolate = Jp2kSandbox.createIsolate(
-                            sandbox = sandbox,
-                            maxHeapSizeBytes = config.maxHeapSizeBytes,
-                            maxEvaluationReturnSizeBytes = config.maxEvaluationReturnSizeBytes,
-                        ).also { isolate ->
-                            Jp2kSandbox.setupConsoleCallback(isolate, sandbox, mainExecutor, TAG)
-                        }
-                        continuation.resume(Unit)
-                    } catch (exception: Exception) {
-                        continuation.resumeWithException(exception)
-                    }
-                }, mainExecutor)
+    suspend fun init() = suspendCancellableCoroutine { continuation ->
+        jp2kDecoderAsync.init(object : Callback<Unit> {
+            override fun onSuccess(result: Unit) {
+                continuation.resume(result)
             }
-            loadWasm()
-            val time = System.currentTimeMillis() - start
-            log(Log.INFO, "init() finished in $time msec")
-        } catch (e: Exception) {
-            val time = System.currentTimeMillis() - start
-            log(Log.ERROR, "init() failed in $time msec. Error: ${e.message}")
-            throw e
-        }
-    }
 
-    private suspend fun loadWasm() = withContext(Dispatchers.IO) {
-        val wasmArrayString = assetManager.open(ASSET_PATH_WASM)
-            .readBytes()
-            .joinToString(",")
-
-        val script = """
-        var wasmInstance;
-        const wasmBuffer = new Uint8Array([$wasmArrayString]);
-
-        $SCRIPT_IMPORT_OBJECT
-
-        WebAssembly.instantiate(wasmBuffer, importObject).then(res => {
-            wasmInstance = res.instance;
-
-            $SCRIPT_DEFINE_DECODE_J2K
-        
-            return "1";
-        });
-        """.trimIndent()
-
-        val resultFuture = jsIsolate?.evaluateJavaScriptAsync(script)
-
-        suspendCancellableCoroutine { continuation ->
-            resultFuture?.addListener({
-                @Suppress("BlockingMethodInNonBlockingContext")
-                if (resultFuture.get() == "1") {
-                    continuation.resume(Unit)
-                } else {
-                    continuation.resumeWithException(IllegalStateException())
-                }
-            }, mainExecutor)
-        }
+            override fun onError(error: Exception) {
+                continuation.resumeWithException(error)
+            }
+        })
     }
 
     /**
@@ -117,72 +47,20 @@ class Jp2kDecoder(
      * @param j2kData The raw byte array of the JPEG 2000 image.
      * @param colorFormat The desired output color format. Defaults to [ColorFormat.ARGB8888].
      * @return The decoded [Bitmap].
-     * @throws IllegalArgumentException If the input data is too short.
-     * @throws IllegalStateException If the decoder has not been initialized.
-     * @throws Jp2kException If a decoding error occurs.
      */
-    suspend fun decodeImage(j2kData: ByteArray, colorFormat: ColorFormat = ColorFormat.ARGB8888): Bitmap {
-        val start = System.currentTimeMillis()
-        log(Log.INFO, "Input data length: ${j2kData.size}")
-
-        if (j2kData.size < MIN_INPUT_SIZE) {
-            throw IllegalArgumentException("Input data is too short")
-        }
-
-        try {
-            val jsIsolate = checkNotNull(jsIsolate) { "Jp2kDecoder has not been initialized." }
-
-            // Optimization: Use Hex string instead of joinToString(",") to reduce memory overhead and string size
-            val dataHexString = j2kData.toHexString()
-            val script = "globalThis.decodeJ2K('$dataHexString', ${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id});"
-
-            val resultFuture = jsIsolate.evaluateJavaScriptAsync(script)
-
-            val structureJson = suspendCancellableCoroutine { continuation ->
-                resultFuture?.addListener({
-                    val jsonResult = resultFuture.get()
-                    continuation.resume(jsonResult)
-                }, mainExecutor)
+    suspend fun decodeImage(
+        j2kData: ByteArray,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+    ): Bitmap = suspendCancellableCoroutine { continuation ->
+        jp2kDecoderAsync.decodeImage(j2kData, colorFormat, object : Callback<Bitmap> {
+            override fun onSuccess(result: Bitmap) {
+                continuation.resume(result)
             }
 
-            val root = JSONObject(structureJson)
-            if (root.has("errorCode")) {
-                val errorCode = root.getInt("errorCode")
-                val error = Jp2kError.fromInt(errorCode)
-                log(Log.ERROR, "Error: $error")
-                throw Jp2kException(error)
-            } else if (root.has("error")) {
-                val errorMsg = root.getString("error")
-                log(Log.ERROR, "Error: $errorMsg")
-                throw Jp2kException(Jp2kError.Unknown, errorMsg)
+            override fun onError(error: Exception) {
+                continuation.resumeWithException(error)
             }
-
-            val bmpHex = root.getString("bmp")
-
-            @OptIn(ExperimentalStdlibApi::class)
-            val bmpBytes = bmpHex.hexToByteArray()
-
-            log(Log.INFO, "Output data length: ${bmpBytes.size}")
-
-            val options = BitmapFactory.Options().apply {
-                inPreferredConfig = when (colorFormat) {
-                    ColorFormat.RGB565 -> Bitmap.Config.RGB_565
-                    ColorFormat.ARGB8888 -> Bitmap.Config.ARGB_8888
-                }
-            }
-
-            val bitmap = BitmapFactory.decodeByteArray(bmpBytes, 0, bmpBytes.size, options)
-                ?: throw IllegalStateException("Bitmap decoding failed (returned null).")
-
-            val time = System.currentTimeMillis() - start
-            log(Log.INFO, "decodeImage() finished in $time msec")
-
-            return bitmap
-        } catch (e: Exception) {
-            val time = System.currentTimeMillis() - start
-            log(Log.ERROR, "decodeImage() failed in $time msec. Error: ${e.message}")
-            throw e
-        }
+        })
     }
 
     /**
@@ -191,79 +69,6 @@ class Jp2kDecoder(
      * This closes the JavaScript isolate. It should be called when the decoder is no longer needed.
      */
     fun release() {
-        try {
-            jsIsolate?.close()
-            jsIsolate = null
-        } catch (e: Exception) {
-            log(Log.ERROR, "Error closing isolate: ${e.message}")
-        }
-    }
-
-    companion object {
-        private const val TAG = "Jp2kDecoder"
-
-        private const val SCRIPT_DEFINE_DECODE_J2K = """
-            globalThis.bytesToHex = function(bytes) {
-                const hexChars = "0123456789abcdef";
-                let output = "";
-                for (let i = 0; i < bytes.length; i++) {
-                    const b = bytes[i];
-                    output += hexChars[(b >> 4) & 0xf];
-                    output += hexChars[b & 0xf];
-                }
-                return output;
-            };
-
-            globalThis.hexToBytes = function(hex) {
-                const len = hex.length;
-                if (len === 0) return new Uint8Array(0);
-                const bytes = new Uint8Array(len / 2);
-                for (let i = 0; i < len; i += 2) {
-                    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
-                }
-                return bytes;
-            };
-
-            globalThis.decodeJ2K = function(dataHexString, maxPixels, maxHeapSize, colorFormat) {
-                try {
-                    const exports = wasmInstance.exports;
-
-                    const encodedBuffer = globalThis.hexToBytes(dataHexString);
-
-                    const dataLength = encodedBuffer.length;
-                    if (dataLength === 0) return JSON.stringify({ errorCode: -1 });
-            
-                    const inputPtr = exports.malloc(dataLength);
-                    const heap = new Uint8Array(exports.memory.buffer);
-                    
-                    heap.set(encodedBuffer, inputPtr);
-                    
-                    // Call decodeToBmp (exported as _decodeToBmp or similar in WASM, mapped here)
-                    const bmpPtr = exports.decodeToBmp(inputPtr, encodedBuffer.length, maxPixels, maxHeapSize, colorFormat);
-
-                    if (bmpPtr === 0) {
-                        const errorCode = exports.getLastError();
-                        exports.free(inputPtr);
-                        return JSON.stringify({ errorCode: errorCode });
-                    }
-                    
-                    // BMP file size at offset 2
-                    const view = new DataView(exports.memory.buffer);
-                    const bmpSize = view.getUint32(bmpPtr + 2, true);
-
-                    const bmpBuffer = new Uint8Array(exports.memory.buffer, bmpPtr, bmpSize);
-                    const hexString = globalThis.bytesToHex(bmpBuffer);
-
-                    exports.free(bmpPtr);
-                    exports.free(inputPtr);
-                
-                    return JSON.stringify({
-                        bmp: hexString
-                    });
-                } catch (e) {
-                    return JSON.stringify({ error: e.toString() });
-                }
-            };            
-        """
+        jp2kDecoderAsync.release()
     }
 }


### PR DESCRIPTION
- Delegate `Jp2kDecoder` implementation to `Jp2kDecoderAsync`.
- Update Android source and target compatibility to Java 21.
- Apply `kotlin-android` plugin to project modules.
- Remove manual Dokka source set configuration.