### PR TITLE
Refactor build script to use Gradle Provider API for env vars

### DIFF
--- a/android/lib/build.gradle.kts
+++ b/android/lib/build.gradle.kts
@@ -14,8 +14,8 @@ plugins {
 
 nmcpAggregation {
     centralPortal {
-        username = System.getenv("CENTRAL_PORTAL_USERNAME")
-        password = System.getenv("CENTRAL_PORTAL_PASSWORD")
+        username = providers.environmentVariable("CENTRAL_PORTAL_USERNAME")
+        password = providers.environmentVariable("CENTRAL_PORTAL_PASSWORD")
         publishingType = "USER_MANAGED"
     }
 }


### PR DESCRIPTION
Updated the build script `android/lib/build.gradle.kts` to use Gradle's `providers.environmentVariable` API for accessing environment variables `CENTRAL_PORTAL_USERNAME` and `CENTRAL_PORTAL_PASSWORD`. This change allows for lazy evaluation, which is crucial for Gradle's configuration cache compatibility and improved build performance. Verified that the build configuration remains valid using `./gradlew help`.

---
*PR created automatically by Jules for task [12043127947145456891](https://jules.google.com/task/12043127947145456891) started by @keiji*