### PR TITLE
Refactor: Use Gradle Provider API for environment variables in build script

### DIFF
--- a/android/lib/build.gradle.kts
+++ b/android/lib/build.gradle.kts
@@ -14,8 +14,8 @@ plugins {
 
 nmcpAggregation {
     centralPortal {
-        username = System.getenv("CENTRAL_PORTAL_USERNAME")
-        password = System.getenv("CENTRAL_PORTAL_PASSWORD")
+        username = providers.environmentVariable("CENTRAL_PORTAL_USERNAME")
+        password = providers.environmentVariable("CENTRAL_PORTAL_PASSWORD")
         publishingType = "USER_MANAGED"
     }
 }


### PR DESCRIPTION
Use Gradle Provider API for environment variables in build script

---
*PR created automatically by Jules for task [17594474454618588620](https://jules.google.com/task/17594474454618588620) started by @keiji*