### PR TITLE
Add coverage measurement and reporting for C and Android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
         continue-on-error: true
 
       - name: Report Android Lint Results
+        if: github.event_name == 'pull_request'
         uses: dvdandroid/action-android-lint@v1.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -46,6 +47,19 @@ jobs:
       - name: Build Android App & Lib
         working-directory: android
         run: ./gradlew assembleDebug
+
+      - name: Run Unit Tests & Coverage
+        working-directory: android
+        run: ./gradlew :lib:testDebugUnitTest :lib:jacocoTestReport
+
+      - name: Report Android Coverage
+        if: github.event_name == 'pull_request'
+        uses: Madrapps/jacoco-report@v1.7.1
+        with:
+          paths: android/lib/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 0
+          title: "Android Code Coverage"
 
       - name: Generate Documentation
         working-directory: android
@@ -62,14 +76,38 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: recursive
 
-      - name: Run C Wrapper Tests
-        run: bash test/run_tests.sh
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov
+
+      - name: Run C Wrapper Tests with Coverage
+        run: bash test/run_coverage.sh
+
+      - name: Report C Coverage
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            try {
+              if (fs.existsSync('coverage_summary.txt')) {
+                const summary = fs.readFileSync('coverage_summary.txt', 'utf8');
+                github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: '## C Wrapper Coverage\n```\n' + summary + '\n```'
+                });
+              }
+            } catch (error) {
+              console.log('Error posting comment: ' + error);
+            }
 
       - name: Setup Emscripten
         uses: mymindstorm/setup-emsdk@v14

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,21 @@
-openjpeg/build
+# Gradle files
+.gradle/
+build/
+*/build/
+
+# Wrapper
+!gradle/wrapper/gradle-wrapper.jar
+
+# Android Studio
+.idea/
+*.iml
+local.properties
+
+# OS
+.DS_Store
+
+# Coverage
+*.gcda
+*.gcno
+coverage.info
+coverage_summary.txt

--- a/android/lib/build.gradle.kts
+++ b/android/lib/build.gradle.kts
@@ -10,9 +10,8 @@ plugins {
     alias(libs.plugins.nmcp.aggregation)
     `maven-publish`
     signing
+    jacoco
 }
-
-apply(plugin = "jacoco")
 
 nmcpAggregation {
     centralPortal {
@@ -129,11 +128,11 @@ tasks.register<JacocoReport>("jacocoTestReport") {
         html.required.set(true)
     }
 
-    val fileFilter = listOf("**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*", "android/**/*.*")
+    val fileFilter = listOf("**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*", "**/*Test*.*")
     val debugTree = layout.buildDirectory.dir("tmp/kotlin-classes/debug").get().asFileTree.matching {
         exclude(fileFilter)
     }
-    val mainSrc = layout.projectDirectory.dir("src/main/java")
+    val mainSrc = android.sourceSets.getByName("main").java.srcDirs
 
     classDirectories.setFrom(debugTree)
     sourceDirectories.setFrom(files(mainSrc))

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Clean previous coverage
+rm -f *.gcda *.gcno coverage.info coverage_summary.txt
+
+# Compile with coverage flags
+gcc -o test_wrapper_cov test/test_wrapper.c test/stubs.c \
+    -I. -Iopenjpeg/src/lib/openjp2 -Itest -DOPJ_STATIC \
+    -fprofile-arcs -ftest-coverage -g
+
+# Run the test executable
+./test_wrapper_cov
+
+# Capture coverage (only if lcov is available)
+if command -v lcov >/dev/null 2>&1; then
+    lcov --capture --directory . --output-file coverage.info
+    lcov --extract coverage.info '*/wrapper.c' --output-file coverage.info
+    lcov --list coverage.info > coverage_summary.txt
+    cat coverage_summary.txt
+else
+    echo "lcov not found, skipping report generation."
+fi
+
+# Clean up
+rm -f test_wrapper_cov

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -4,6 +4,11 @@ set -e
 # Clean previous coverage
 rm -f *.gcda *.gcno coverage.info coverage_summary.txt
 
+cleanup() {
+  rm -f test_wrapper_cov *.gcda *.gcno coverage.info
+}
+trap cleanup EXIT
+
 # Compile with coverage flags
 gcc -o test_wrapper_cov test/test_wrapper.c test/stubs.c \
     -I. -Iopenjpeg/src/lib/openjp2 -Itest -DOPJ_STATIC \
@@ -15,12 +20,12 @@ gcc -o test_wrapper_cov test/test_wrapper.c test/stubs.c \
 # Capture coverage (only if lcov is available)
 if command -v lcov >/dev/null 2>&1; then
     lcov --capture --directory . --output-file coverage.info
-    lcov --extract coverage.info '*/wrapper.c' --output-file coverage.info
-    lcov --list coverage.info > coverage_summary.txt
+    lcov --extract coverage.info '*/wrapper.c' --output-file coverage_filtered.info
+    lcov --list coverage_filtered.info > coverage_summary.txt
     cat coverage_summary.txt
 else
     echo "lcov not found, skipping report generation."
 fi
 
 # Clean up
-rm -f test_wrapper_cov
+# rm -f test_wrapper_cov (handled by trap)


### PR DESCRIPTION
This PR adds automated test coverage measurement and reporting to the CI pipeline.

### C Coverage
* Added `test/run_coverage.sh` which compiles `wrapper.c` and its tests with `--coverage`, runs them, and generates an LCOV report.
* Added steps to the `wasm` job in `.github/workflows/build.yml` to install `lcov`, run the script, and post the summary as a PR comment.

### Android Coverage
* Applied `jacoco` plugin to `android/lib`.
* Enabled `enableUnitTestCoverage` and `enableAndroidTestCoverage` for the debug build type.
* Registered a `jacocoTestReport` task to generate XML/HTML reports.
* Added steps to the `android` job in `.github/workflows/build.yml` to run unit tests, generate the report, and use `Madrapps/jacoco-report` to comment on the PR.

Note: Android coverage currently only runs Unit Tests (Robolectric/Local), so coverage might be low until tests are migrated or an emulator is added to CI.

---
*PR created automatically by Jules for task [15504526977522100647](https://jules.google.com/task/15504526977522100647) started by @keiji*