### PR TITLE
Add cached data support to Jp2kDecoder and Jp2kDecoderAsync

### DIFF
--- a/android/app/src/main/java/dev/keiji/j2k_wasm_sample/MainActivity.kt
+++ b/android/app/src/main/java/dev/keiji/j2k_wasm_sample/MainActivity.kt
@@ -62,9 +62,10 @@ class MainActivity : ComponentActivity() {
                                 }
                                 Jp2kDecoder().use { decoder ->
                                     decoder.init(applicationContext)
+                                    decoder.precache(bytes)
                                     val usageBefore = decoder.getMemoryUsage()
-                                    val imageSize = decoder.getSize(bytes)
-                                    val bmp = decoder.decodeImage(bytes)
+                                    val imageSize = decoder.getSize()
+                                    val bmp = decoder.decodeImage()
                                     val usageAfter = decoder.getMemoryUsage()
                                     DecodeResult(
                                         bmp = bmp,

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ composeBom = "2026.01.01"
 coroutines = "1.10.2"
 dokka = "2.1.0"
 nmcp = "1.4.4"
+mockito = "5.2.0"
+json = "20240303"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +33,10 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
+mockito-inline = { group = "org.mockito", name = "mockito-inline", version.ref = "mockito" }
+mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version = "5.2.1" }
+json = { group = "org.json", name = "json", version.ref = "json" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/android/lib/build.gradle.kts
+++ b/android/lib/build.gradle.kts
@@ -65,6 +65,11 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.inline)
+    testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.json)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.kotlinx.coroutines.test)

--- a/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
@@ -19,6 +19,8 @@ const val DEFAULT_MAX_EVALUATION_RETURN_SIZE_BYTES = 256 * 1024 * 1024
  */
 const val DEFAULT_MAX_PIXELS = 16000000
 
+internal const val INTERNAL_RESULT_SUCCESS = "1"
+
 internal const val SCRIPT_IMPORT_OBJECT = """
 const wasiSnapshotPreview = {
     // 環境変数の数とサイズ
@@ -133,7 +135,7 @@ internal val SCRIPT_DEFINE_SET_DATA = """
             globalThis.setData = function(dataBase64String) {
                 try {
                     globalThis.j2kData = globalThis.base64ToBytes(dataBase64String);
-                    return "1";
+                    return "$INTERNAL_RESULT_SUCCESS";
                 } catch (e) {
                     return JSON.stringify({ errorCode: ${Jp2kError.Unknown.code}, errorMessage: e.toString() });
                 }
@@ -219,7 +221,7 @@ internal val SCRIPT_DEFINE_DECODE_J2K = """
 
             globalThis.decodeJ2KWithCache = function(maxPixels, maxHeapSize, colorFormat, measureTimes) {
                 if (!globalThis.j2kData) {
-                    return JSON.stringify({ errorCode: -10, errorMessage: "No data cached" });
+                    return JSON.stringify({ errorCode: ${Jp2kError.CacheDataMissing.code}, errorMessage: "No data cached" });
                 }
                 return globalThis.internalDecodeJ2K(globalThis.j2kData, maxPixels, maxHeapSize, colorFormat, measureTimes);
             };
@@ -287,7 +289,7 @@ internal val SCRIPT_DEFINE_GET_SIZE = """
 
             globalThis.getSizeWithCache = function() {
                 if (!globalThis.j2kData) {
-                    return JSON.stringify({ errorCode: -10, errorMessage: "No data cached" });
+                    return JSON.stringify({ errorCode: ${Jp2kError.CacheDataMissing.code}, errorMessage: "No data cached" });
                 }
                 return globalThis.internalGetSize(globalThis.j2kData);
             };

--- a/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
@@ -219,7 +219,7 @@ internal val SCRIPT_DEFINE_DECODE_J2K = """
 
             globalThis.decodeJ2KWithCache = function(maxPixels, maxHeapSize, colorFormat, measureTimes) {
                 if (!globalThis.j2kData) {
-                    return JSON.stringify({ errorCode: -1, errorMessage: "No data cached" });
+                    return JSON.stringify({ errorCode: -10, errorMessage: "No data cached" });
                 }
                 return globalThis.internalDecodeJ2K(globalThis.j2kData, maxPixels, maxHeapSize, colorFormat, measureTimes);
             };
@@ -287,7 +287,7 @@ internal val SCRIPT_DEFINE_GET_SIZE = """
 
             globalThis.getSizeWithCache = function() {
                 if (!globalThis.j2kData) {
-                    return JSON.stringify({ errorCode: -1, errorMessage: "No data cached" });
+                    return JSON.stringify({ errorCode: -10, errorMessage: "No data cached" });
                 }
                 return globalThis.internalGetSize(globalThis.j2kData);
             };

--- a/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
@@ -128,8 +128,20 @@ internal const val SCRIPT_BYTES_BASE64_CONVERTER = """
             };
 """
 
+internal val SCRIPT_DEFINE_SET_DATA = """
+            globalThis.j2kData = null;
+            globalThis.setData = function(dataBase64String) {
+                try {
+                    globalThis.j2kData = globalThis.base64ToBytes(dataBase64String);
+                    return "1";
+                } catch (e) {
+                    return JSON.stringify({ errorCode: ${Jp2kError.Unknown.code}, errorMessage: e.toString() });
+                }
+            };
+"""
+
 internal val SCRIPT_DEFINE_DECODE_J2K = """
-            globalThis.decodeJ2K = function(dataBase64String, maxPixels, maxHeapSize, colorFormat, measureTimes) {
+            globalThis.internalDecodeJ2K = function(encodedBuffer, maxPixels, maxHeapSize, colorFormat, measureTimes) {
                 const now = function() {
                     return (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
                 };
@@ -141,8 +153,6 @@ internal val SCRIPT_DEFINE_DECODE_J2K = """
                     }
 
                     const exports = wasmInstance.exports;
-
-                    const encodedBuffer = globalThis.base64ToBytes(dataBase64String);
 
                     const dataLength = encodedBuffer.length;
                     if (dataLength === 0) return JSON.stringify({ errorCode: -1 });
@@ -198,6 +208,22 @@ internal val SCRIPT_DEFINE_DECODE_J2K = """
                 }
             };
 
+            globalThis.decodeJ2K = function(dataBase64String, maxPixels, maxHeapSize, colorFormat, measureTimes) {
+                try {
+                    const encodedBuffer = globalThis.base64ToBytes(dataBase64String);
+                    return globalThis.internalDecodeJ2K(encodedBuffer, maxPixels, maxHeapSize, colorFormat, measureTimes);
+                } catch (e) {
+                    return JSON.stringify({ errorCode: ${Jp2kError.Unknown.code}, errorMessage: e.toString() });
+                }
+            };
+
+            globalThis.decodeJ2KWithCache = function(maxPixels, maxHeapSize, colorFormat, measureTimes) {
+                if (!globalThis.j2kData) {
+                    return JSON.stringify({ errorCode: -1, errorMessage: "No data cached" });
+                }
+                return globalThis.internalDecodeJ2K(globalThis.j2kData, maxPixels, maxHeapSize, colorFormat, measureTimes);
+            };
+
             globalThis.getMemoryUsage = function() {
                 let wasmHeap = 0;
                 try {
@@ -213,10 +239,9 @@ internal val SCRIPT_DEFINE_DECODE_J2K = """
         """
 
 internal val SCRIPT_DEFINE_GET_SIZE = """
-            globalThis.getSize = function(dataBase64String) {
+            globalThis.internalGetSize = function(encodedBuffer) {
                 try {
                     const exports = wasmInstance.exports;
-                    const encodedBuffer = globalThis.base64ToBytes(dataBase64String);
                     const dataLength = encodedBuffer.length;
 
                     if (dataLength === 0) return JSON.stringify({ errorCode: -1 });
@@ -249,5 +274,21 @@ internal val SCRIPT_DEFINE_GET_SIZE = """
                 } catch (e) {
                     return JSON.stringify({ errorCode: ${Jp2kError.Unknown.code}, errorMessage: e.toString() });
                 }
+            };
+
+            globalThis.getSize = function(dataBase64String) {
+                try {
+                    const encodedBuffer = globalThis.base64ToBytes(dataBase64String);
+                    return globalThis.internalGetSize(encodedBuffer);
+                } catch (e) {
+                    return JSON.stringify({ errorCode: ${Jp2kError.Unknown.code}, errorMessage: e.toString() });
+                }
+            };
+
+            globalThis.getSizeWithCache = function() {
+                if (!globalThis.j2kData) {
+                    return JSON.stringify({ errorCode: -1, errorMessage: "No data cached" });
+                }
+                return globalThis.internalGetSize(globalThis.j2kData);
             };
         """

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -227,6 +227,9 @@ class Jp2kDecoder(
                 val root = JSONObject(jsonResult)
                 if (root.has("errorCode")) {
                     val errorCode = root.getInt("errorCode")
+                    if (errorCode == -10) {
+                        throw IllegalStateException("No data cached")
+                    }
                     val error = Jp2kError.fromInt(errorCode)
                     val errorMessage = if (root.has("errorMessage")) root.getString("errorMessage") else null
                     log(Log.ERROR, "Error: $error, Message: $errorMessage")
@@ -276,6 +279,9 @@ class Jp2kDecoder(
                 val root = JSONObject(jsonResult)
                 if (root.has("errorCode")) {
                     val errorCode = root.getInt("errorCode")
+                    if (errorCode == -10) {
+                        throw IllegalStateException("No data cached")
+                    }
                     val error = Jp2kError.fromInt(errorCode)
                     val errorMessage = if (root.has("errorMessage")) root.getString("errorMessage") else null
                     log(Log.ERROR, "Error: $error, Message: $errorMessage")

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -142,7 +142,7 @@ class Jp2kDecoder(
             val resultFuture = isolate.evaluateJavaScriptAsync(script)
             try {
                 val result = resultFuture.await()
-                if (result != "1") {
+                if (result != INTERNAL_RESULT_SUCCESS) {
                     throw IllegalStateException("WASM instantiation failed.")
                 }
             } catch (e: ExecutionException) {
@@ -179,7 +179,7 @@ class Jp2kDecoder(
                     val resultFuture = isolate.evaluateJavaScriptAsync(script)
                     val result = resultFuture.await()
 
-                    if (result != "1") {
+                    if (result != INTERNAL_RESULT_SUCCESS) {
                         val root = JSONObject(result)
                         if (root.has("errorCode")) {
                             val errorCode = root.getInt("errorCode")
@@ -238,7 +238,7 @@ class Jp2kDecoder(
                 val root = JSONObject(jsonResult)
                 if (root.has("errorCode")) {
                     val errorCode = root.getInt("errorCode")
-                    if (errorCode == -10) {
+                    if (errorCode == Jp2kError.CacheDataMissing.code) {
                         throw IllegalStateException("No data cached")
                     }
                     val error = Jp2kError.fromInt(errorCode)
@@ -332,7 +332,7 @@ class Jp2kDecoder(
                 val root = JSONObject(jsonResult)
                 if (root.has("errorCode")) {
                     val errorCode = root.getInt("errorCode")
-                    if (errorCode == -10) {
+                    if (errorCode == Jp2kError.CacheDataMissing.code) {
                         throw IllegalStateException("No data cached")
                     }
                     val error = Jp2kError.fromInt(errorCode)

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -167,6 +167,7 @@ class Jp2kDecoder(
         if (_state != State.Initialized) {
             throw IllegalStateException("Cannot precache while in state: $_state")
         }
+        _state = State.Processing
 
         try {
             val isolate = checkNotNull(jsIsolate) { "Jp2kDecoder has not been initialized." }
@@ -193,6 +194,8 @@ class Jp2kDecoder(
         } catch (e: Exception) {
             log(Log.ERROR, "precache() failed. Error: ${e.message}")
             throw e
+        } finally {
+            restoreStateAfterDecode()
         }
     }
 

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -161,7 +161,7 @@ class Jp2kDecoderAsync(
 
         try {
             val result = resultFuture.get()
-            if (result != "1") {
+            if (result != INTERNAL_RESULT_SUCCESS) {
                 throw IllegalStateException("WASM instantiation failed.")
             }
         } catch (e: ExecutionException) {
@@ -242,7 +242,7 @@ class Jp2kDecoderAsync(
                     val resultFuture = isolate!!.evaluateJavaScriptAsync(script)
                     val result = resultFuture.get()
 
-                    if (result != "1") {
+                    if (result != INTERNAL_RESULT_SUCCESS) {
                          val root = JSONObject(result)
                          if (root.has("errorCode")) {
                             val errorCode = root.getInt("errorCode")
@@ -329,7 +329,7 @@ class Jp2kDecoderAsync(
                     val root = JSONObject(jsonResult)
                     if (root.has("errorCode")) {
                         val errorCode = root.getInt("errorCode")
-                        if (errorCode == -10) {
+                        if (errorCode == Jp2kError.CacheDataMissing.code) {
                             throw IllegalStateException("No data cached")
                         }
                         val error = Jp2kError.fromInt(errorCode)
@@ -453,7 +453,7 @@ class Jp2kDecoderAsync(
                     val root = JSONObject(jsonResult)
                     if (root.has("errorCode")) {
                         val errorCode = root.getInt("errorCode")
-                        if (errorCode == -10) {
+                        if (errorCode == Jp2kError.CacheDataMissing.code) {
                             throw IllegalStateException("No data cached")
                         }
                         val error = Jp2kError.fromInt(errorCode)

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -314,6 +314,9 @@ class Jp2kDecoderAsync(
                     val root = JSONObject(jsonResult)
                     if (root.has("errorCode")) {
                         val errorCode = root.getInt("errorCode")
+                        if (errorCode == -10) {
+                            throw IllegalStateException("No data cached")
+                        }
                         val error = Jp2kError.fromInt(errorCode)
                         val errorMessage = if (root.has("errorMessage")) root.getString("errorMessage") else null
                         log(Log.ERROR, "Error: $error, Message: $errorMessage")
@@ -392,6 +395,9 @@ class Jp2kDecoderAsync(
                     val root = JSONObject(jsonResult)
                     if (root.has("errorCode")) {
                         val errorCode = root.getInt("errorCode")
+                        if (errorCode == -10) {
+                            throw IllegalStateException("No data cached")
+                        }
                         val error = Jp2kError.fromInt(errorCode)
                         val errorMessage = if (root.has("errorMessage")) root.getString("errorMessage") else null
                         log(Log.ERROR, "Error: $error, Message: $errorMessage")

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -138,6 +138,7 @@ class Jp2kDecoderAsync(
 
         val script = """
         $SCRIPT_BYTES_BASE64_CONVERTER
+        $SCRIPT_DEFINE_SET_DATA
 
         var wasmInstance;
         const wasmBuffer = globalThis.base64ToBytes('$wasmBase64String');
@@ -165,6 +166,184 @@ class Jp2kDecoderAsync(
             }
         } catch (e: ExecutionException) {
             throw e.cause ?: e
+        }
+    }
+
+    /**
+     * Initializes the decoder asynchronously with initial image data.
+     *
+     * This method initializes the JavaScript sandbox, loads the WebAssembly module,
+     * and caches the provided image data in the sandbox for subsequent operations.
+     *
+     * @param context The Android Context.
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param callback The callback to receive the initialization result.
+     */
+    fun init(context: Context, j2kData: ByteArray, callback: Callback<Unit>) {
+        synchronized(lock) {
+            if (_state == State.Initialized) {
+                // Already initialized, just set data?
+                // We will proceed to set data if already initialized.
+            } else if (_state == State.Released || _state == State.Releasing) {
+                callback.onError(CancellationException("Decoder was released."))
+                return
+            } else if (_state != State.Uninitialized) {
+                callback.onError(IllegalStateException("Cannot initialize while in state: $_state"))
+                return
+            }
+            if (_state == State.Uninitialized) {
+                _state = State.Initializing
+            }
+        }
+
+        val assetManager = context.assets
+        val mainExecutor = ContextCompat.getMainExecutor(context)
+        val sandboxFuture = Jp2kSandbox.get(context)
+
+        val start = System.currentTimeMillis()
+        backgroundExecutor.execute {
+            synchronized(executionLock) {
+                try {
+                    var isolate = jsIsolate
+                    if (isolate == null) {
+                        // Wait for sandbox connection on the background thread
+                        val sandbox = sandboxFuture.get()
+                        isolate = Jp2kSandbox.createIsolate(
+                            sandbox = sandbox,
+                            maxHeapSizeBytes = config.maxHeapSizeBytes,
+                            maxEvaluationReturnSizeBytes = config.maxEvaluationReturnSizeBytes,
+                        ).also { iso ->
+                            Jp2kSandbox.setupConsoleCallback(iso, sandbox, mainExecutor, TAG)
+                        }
+
+                        synchronized(lock) {
+                            if (_state == State.Released || _state == State.Releasing) {
+                                isolate.close()
+                                throw CancellationException("Jp2kDecoderAsync was released during initialization.")
+                            }
+                            jsIsolate = isolate
+                        }
+
+                        // Load WASM
+                        loadWasm(isolate, assetManager)
+
+                        synchronized(lock) {
+                            if (_state == State.Released || _state == State.Releasing) {
+                                throw CancellationException("Jp2kDecoderAsync was released during initialization.")
+                            }
+                            _state = State.Initialized
+                        }
+                    }
+
+                    // Set Data
+                    val dataBase64String = Base64.getEncoder().encodeToString(j2kData)
+                    val script = "globalThis.setData('$dataBase64String');"
+
+                    val resultFuture = isolate!!.evaluateJavaScriptAsync(script)
+                    val result = resultFuture.get()
+
+                    if (result != "1") {
+                         val root = JSONObject(result)
+                         if (root.has("errorCode")) {
+                            val errorCode = root.getInt("errorCode")
+                            val error = Jp2kError.fromInt(errorCode)
+                            val errorMessage = if (root.has("errorMessage")) root.getString("errorMessage") else null
+                            log(Log.ERROR, "Error: $error, Message: $errorMessage")
+                            throw Jp2kException(error, errorMessage)
+                         }
+                         throw IllegalStateException("Failed to set data: $result")
+                    }
+
+                    val time = System.currentTimeMillis() - start
+                    log(Log.INFO, "init(data) finished in $time msec")
+                    callback.onSuccess(Unit)
+                } catch (e: Exception) {
+                    synchronized(lock) {
+                        if (_state == State.Initializing) {
+                            _state = State.Uninitialized
+                        }
+                    }
+                    val time = System.currentTimeMillis() - start
+                    log(Log.ERROR, "init(data) failed in $time msec. Error: ${e.message}")
+                    callback.onError(e)
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieves the size of the JPEG 2000 image asynchronously using cached data.
+     *
+     * @param callback The callback to receive the [Size] or error.
+     */
+    fun getSize(callback: Callback<Size>) {
+        synchronized(lock) {
+            if (_state == State.Released || _state == State.Releasing) {
+                callback.onError(CancellationException("Decoder was released."))
+                return
+            }
+            if (_state != State.Initialized && _state != State.Processing) {
+                callback.onError(IllegalStateException("Cannot getSize while in state: $_state"))
+                return
+            }
+        }
+
+        backgroundExecutor.execute {
+            synchronized(executionLock) {
+                synchronized(lock) {
+                    if (_state == State.Released || _state == State.Releasing) {
+                        callback.onError(CancellationException("Decoder was released."))
+                        return@execute
+                    }
+                    if (_state != State.Initialized && _state != State.Processing) {
+                        callback.onError(IllegalStateException("Decoder state invalid before execution: $_state"))
+                        return@execute
+                    }
+                    _state = State.Processing
+                }
+
+                try {
+                    val isolate = checkNotNull(jsIsolate) { "Jp2kDecoder has not been initialized." }
+
+                    val script = "globalThis.getSizeWithCache();"
+
+                    val resultFuture = isolate.evaluateJavaScriptAsync(script)
+                    val jsonResult =
+                        resultFuture.get() ?: throw IllegalStateException("Result Future is null")
+
+                    val root = JSONObject(jsonResult)
+                    if (root.has("errorCode")) {
+                        val errorCode = root.getInt("errorCode")
+                        val error = Jp2kError.fromInt(errorCode)
+                        val errorMessage = if (root.has("errorMessage")) root.getString("errorMessage") else null
+                        log(Log.ERROR, "Error: $error, Message: $errorMessage")
+                        throw Jp2kException(error, errorMessage)
+                    }
+
+                    val width = root.getInt("width")
+                    val height = root.getInt("height")
+                    val size = Size(width, height)
+
+                    restoreStateAfterDecode()
+                    synchronized(lock) {
+                        if (_state == State.Released || _state == State.Releasing) {
+                            callback.onError(CancellationException("Decoder was released."))
+                        } else {
+                            callback.onSuccess(size)
+                        }
+                    }
+
+                } catch (e: Exception) {
+                    restoreStateAfterDecode()
+                    synchronized(lock) {
+                        if (_state == State.Released || _state == State.Releasing) {
+                            callback.onError(CancellationException("Decoder was released."))
+                        } else {
+                            callback.onError(e)
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -233,6 +412,122 @@ class Jp2kDecoderAsync(
                     }
 
                 } catch (e: Exception) {
+                    restoreStateAfterDecode()
+                    synchronized(lock) {
+                        if (_state == State.Released || _state == State.Releasing) {
+                            callback.onError(CancellationException("Decoder was released."))
+                        } else {
+                            callback.onError(e)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Decodes a JPEG 2000 image asynchronously using cached data.
+     *
+     * @param colorFormat The desired output color format.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(colorFormat: ColorFormat = ColorFormat.ARGB8888, callback: Callback<Bitmap>) {
+        synchronized(lock) {
+            // Allow if Initialized OR Processing (queueing up)
+            if (_state != State.Initialized && _state != State.Processing) {
+                callback.onError(IllegalStateException("Cannot decodeImage while in state: $_state"))
+                return
+            }
+            // Do NOT set state to Processing here. Wait until execution starts.
+        }
+
+        backgroundExecutor.execute {
+            // Serialize execution
+            synchronized(executionLock) {
+                // Check state again inside the serial lock
+                synchronized(lock) {
+                    if (_state == State.Released || _state == State.Releasing) {
+                        callback.onError(CancellationException("Decoder was released."))
+                        return@execute
+                    }
+                    if (_state != State.Initialized && _state != State.Processing) {
+                        callback.onError(IllegalStateException("Decoder state invalid before execution: $_state"))
+                        return@execute
+                    }
+                    _state = State.Processing
+                }
+
+                val start = System.currentTimeMillis()
+
+                try {
+                    val isolate = checkNotNull(jsIsolate) { "Jp2kDecoder has not been initialized." }
+
+                    val measureTimes = config.logLevel != null
+                    val script = "globalThis.decodeJ2KWithCache(${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes);"
+
+                    val resultFuture = isolate.evaluateJavaScriptAsync(script)
+
+                    // Block and wait for result on background thread
+                    val jsonResult =
+                        resultFuture.get() ?: throw IllegalStateException("Result Future is null")
+
+                    val root = JSONObject(jsonResult)
+                    if (root.has("errorCode")) {
+                        val errorCode = root.getInt("errorCode")
+                        val error = Jp2kError.fromInt(errorCode)
+                        val errorMessage = if (root.has("errorMessage")) root.getString("errorMessage") else null
+                        log(Log.ERROR, "Error: $error, Message: $errorMessage")
+                        throw Jp2kException(error, errorMessage)
+                    } else if (root.has("error")) {
+                        val errorMsg = root.getString("error")
+                        log(Log.ERROR, "Error: $errorMsg")
+                        throw Jp2kException(Jp2kError.Unknown, errorMsg)
+                    }
+
+                    if (measureTimes) {
+                        val timePreProcess = root.optDouble("timePreProcess", 0.0)
+                        val timeWasm = root.optDouble("timeWasm", 0.0)
+                        val timePostProcess = root.optDouble("timePostProcess", 0.0)
+                        log(
+                            Log.INFO,
+                            "Pre-process: $timePreProcess ms, WASM: $timeWasm ms, Post-process: $timePostProcess ms"
+                        )
+                    }
+
+                    val bmpBase64 = root.getString("bmp")
+                    val bmpBytes = Base64.getDecoder().decode(bmpBase64)
+
+                    log(Log.INFO, "Output data length: ${bmpBytes.size}")
+
+                    val options = BitmapFactory.Options().apply {
+                        inPreferredConfig = when (colorFormat) {
+                            ColorFormat.RGB565 -> Bitmap.Config.RGB_565
+                            ColorFormat.ARGB8888 -> Bitmap.Config.ARGB_8888
+                        }
+                    }
+
+                    val bitmap = BitmapFactory.decodeByteArray(bmpBytes, 0, bmpBytes.size, options)
+
+                    if (bitmap == null) {
+                        throw IllegalStateException("Bitmap decoding failed (returned null).")
+                    }
+
+                    val time = System.currentTimeMillis() - start
+                    log(Log.INFO, "decodeImage() finished in $time msec")
+
+                    restoreStateAfterDecode()
+                    // Check if released during decode (unlikely due to lock, but good practice)
+                    synchronized(lock) {
+                         if (_state == State.Released || _state == State.Releasing) {
+                             callback.onError(CancellationException("Decoder was released."))
+                         } else {
+                             callback.onSuccess(bitmap)
+                         }
+                    }
+
+                } catch (e: Exception) {
+                    val time = System.currentTimeMillis() - start
+                    log(Log.ERROR, "decodeImage() failed in $time msec. Error: ${e.message}")
                     restoreStateAfterDecode()
                     synchronized(lock) {
                         if (_state == State.Released || _state == State.Releasing) {
@@ -389,6 +684,15 @@ class Jp2kDecoderAsync(
      */
     fun decodeImage(j2kData: ByteArray, callback: Callback<Bitmap>) {
         decodeImage(j2kData, ColorFormat.ARGB8888, callback)
+    }
+
+    /**
+     * Decodes a JPEG 2000 image asynchronously using cached data with default color format (ARGB 8888).
+     *
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(callback: Callback<Bitmap>) {
+        decodeImage(ColorFormat.ARGB8888, callback)
     }
 
     /**

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kError.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kError.kt
@@ -21,6 +21,9 @@ enum class Jp2kError(val code: Int) {
     /** Generic decoding error. */
     Decode(-4),
 
+    /** Cache data missing error. */
+    CacheDataMissing(-10),
+
     /** Unknown error. */
     Unknown(Int.MIN_VALUE);
 

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kSandbox.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kSandbox.kt
@@ -23,6 +23,7 @@ object Jp2kSandbox {
      * @param context The Android Context (will use Application Context internally).
      * @return A [ListenableFuture] that resolves to the [JavaScriptSandbox].
      */
+    @JvmStatic
     fun get(context: Context): ListenableFuture<JavaScriptSandbox> {
         synchronized(lock) {
             if (sandboxFuture == null) {
@@ -41,6 +42,7 @@ object Jp2kSandbox {
      * @param maxEvaluationReturnSizeBytes The maximum return size for evaluation (if supported).
      * @return A new [JavaScriptIsolate] instance.
      */
+    @JvmStatic
     fun createIsolate(
         sandbox: JavaScriptSandbox,
         maxHeapSizeBytes: Long,
@@ -64,6 +66,7 @@ object Jp2kSandbox {
      * @param executor The executor on which the callback will be invoked.
      * @param tag The tag to use for logging.
      */
+    @JvmStatic
     fun setupConsoleCallback(
         isolate: JavaScriptIsolate,
         sandbox: JavaScriptSandbox,

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
@@ -1,0 +1,170 @@
+package dev.keiji.jp2k
+
+import android.content.Context
+import android.content.res.AssetManager
+import androidx.javascriptengine.JavaScriptIsolate
+import androidx.javascriptengine.JavaScriptSandbox
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.contains
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.whenever
+import java.io.ByteArrayInputStream
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+@ExperimentalCoroutinesApi
+class Jp2kDecoderAsyncTest {
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var assetManager: AssetManager
+
+    @Mock
+    lateinit var sandbox: JavaScriptSandbox
+
+    @Mock
+    lateinit var isolate: JavaScriptIsolate
+
+    private lateinit var mockJp2kSandbox: MockedStatic<Jp2kSandbox>
+
+    class TestListenableFuture<T>(private val result: T) : ListenableFuture<T> {
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
+        override fun isCancelled(): Boolean = false
+        override fun isDone(): Boolean = true
+        override fun get(): T = result
+        override fun get(timeout: Long, unit: TimeUnit?): T = result
+        override fun addListener(listener: Runnable, executor: Executor) {
+            listener.run()
+        }
+    }
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+
+        whenever(context.assets).thenReturn(assetManager)
+        whenever(assetManager.open(any<String>())).thenReturn(ByteArrayInputStream(ByteArray(0)))
+
+        mockJp2kSandbox = mockStatic(Jp2kSandbox::class.java)
+
+        mockJp2kSandbox.`when`<ListenableFuture<JavaScriptSandbox>> {
+            Jp2kSandbox.get(any<Context>())
+        }.thenReturn(TestListenableFuture(sandbox))
+
+        mockJp2kSandbox.`when`<JavaScriptIsolate> {
+            Jp2kSandbox.createIsolate(any(), any(), any())
+        }.thenReturn(isolate)
+
+        // Mock sandbox feature support
+        whenever(sandbox.isFeatureSupported(any<String>())).thenReturn(true)
+    }
+
+    @After
+    fun tearDown() {
+        mockJp2kSandbox.close()
+    }
+
+    @Test
+    fun testInitWithData_Success() {
+        // Mock evaluateJavaScriptAsync for WASM load (returns "1") and setData (returns "1")
+        doAnswer { invocation ->
+            // Use simple string matching logic to return appropriate result
+            val script = invocation.arguments[0] as String
+            TestListenableFuture("1")
+        }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        val directExecutor = Executor { it.run() }
+        val decoder = Jp2kDecoderAsync(backgroundExecutor = directExecutor)
+        val data = ByteArray(10)
+
+        val callback = org.mockito.kotlin.mock<Callback<Unit>>()
+        decoder.init(context, data, callback)
+
+        verify(isolate, Mockito.atLeastOnce()).evaluateJavaScriptAsync(contains("setData"))
+        verify(callback).onSuccess(any())
+    }
+
+    @Test
+    fun testGetSize_Success() {
+        val jsonSize = """{"width": 100, "height": 200}"""
+
+        doAnswer { invocation ->
+            val script = invocation.arguments[0] as String
+            if (script.contains("base64ToBytes")) {
+                TestListenableFuture("1")
+            } else if (script.contains("setData")) {
+                TestListenableFuture("1")
+            } else if (script.contains("getSizeWithCache")) {
+                TestListenableFuture(jsonSize)
+            } else {
+                TestListenableFuture("1")
+            }
+        }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        val directExecutor = Executor { it.run() }
+        val decoder = Jp2kDecoderAsync(backgroundExecutor = directExecutor)
+        val data = ByteArray(10)
+
+        val callbackInit = org.mockito.kotlin.mock<Callback<Unit>>()
+        decoder.init(context, data, callbackInit)
+        verify(callbackInit).onSuccess(any())
+
+        val callbackSize = org.mockito.kotlin.mock<Callback<Size>>()
+        decoder.getSize(callbackSize)
+
+        verify(callbackSize).onSuccess(org.mockito.kotlin.check {
+            assertEquals(100, it.width)
+            assertEquals(200, it.height)
+        })
+    }
+
+    @Test
+    fun testGetSize_NoDataCached() {
+        val jsonError = """{"errorCode": -10, "errorMessage": "No data cached"}"""
+
+        doAnswer { invocation ->
+            val script = invocation.arguments[0] as String
+            if (script.contains("base64ToBytes")) {
+                TestListenableFuture("1")
+            } else if (script.contains("getSizeWithCache")) {
+                TestListenableFuture(jsonError)
+            } else {
+                TestListenableFuture("1")
+            }
+        }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        val directExecutor = Executor { it.run() }
+        val decoder = Jp2kDecoderAsync(backgroundExecutor = directExecutor)
+        // Init WITHOUT data
+        val callbackInit = org.mockito.kotlin.mock<Callback<Unit>>()
+        decoder.init(context, callbackInit)
+        verify(callbackInit).onSuccess(any())
+
+        val callbackSize = org.mockito.kotlin.mock<Callback<Size>>()
+        decoder.getSize(callbackSize)
+
+        verify(callbackSize).onError(any())
+    }
+}

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
@@ -92,7 +92,7 @@ class Jp2kDecoderAsyncTest {
         doAnswer { invocation ->
             // Use simple string matching logic to return appropriate result
             val script = invocation.arguments[0] as String
-            TestListenableFuture("1")
+            TestListenableFuture(INTERNAL_RESULT_SUCCESS)
         }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
 
         val directExecutor = Executor { it.run() }
@@ -113,13 +113,13 @@ class Jp2kDecoderAsyncTest {
         doAnswer { invocation ->
             val script = invocation.arguments[0] as String
             if (script.contains("base64ToBytes")) {
-                TestListenableFuture("1")
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
             } else if (script.contains("setData")) {
-                TestListenableFuture("1")
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
             } else if (script.contains("getSizeWithCache")) {
                 TestListenableFuture(jsonSize)
             } else {
-                TestListenableFuture("1")
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
             }
         }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
 

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
@@ -87,7 +87,7 @@ class Jp2kDecoderAsyncTest {
     }
 
     @Test
-    fun testInitWithData_Success() {
+    fun testPrecache_Success() {
         // Mock evaluateJavaScriptAsync for WASM load (returns "1") and setData (returns "1")
         doAnswer { invocation ->
             // Use simple string matching logic to return appropriate result
@@ -99,11 +99,15 @@ class Jp2kDecoderAsyncTest {
         val decoder = Jp2kDecoderAsync(backgroundExecutor = directExecutor)
         val data = ByteArray(10)
 
-        val callback = org.mockito.kotlin.mock<Callback<Unit>>()
-        decoder.init(context, data, callback)
+        val callbackInit = org.mockito.kotlin.mock<Callback<Unit>>()
+        decoder.init(context, callbackInit)
+        verify(callbackInit).onSuccess(any())
+
+        val callbackPrecache = org.mockito.kotlin.mock<Callback<Unit>>()
+        decoder.precache(data, callbackPrecache)
 
         verify(isolate, Mockito.atLeastOnce()).evaluateJavaScriptAsync(contains("setData"))
-        verify(callback).onSuccess(any())
+        verify(callbackPrecache).onSuccess(any())
     }
 
     @Test
@@ -128,8 +132,12 @@ class Jp2kDecoderAsyncTest {
         val data = ByteArray(10)
 
         val callbackInit = org.mockito.kotlin.mock<Callback<Unit>>()
-        decoder.init(context, data, callbackInit)
+        decoder.init(context, callbackInit)
         verify(callbackInit).onSuccess(any())
+
+        val callbackPrecache = org.mockito.kotlin.mock<Callback<Unit>>()
+        decoder.precache(data, callbackPrecache)
+        verify(callbackPrecache).onSuccess(any())
 
         val callbackSize = org.mockito.kotlin.mock<Callback<Size>>()
         decoder.getSize(callbackSize)

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
@@ -150,16 +150,16 @@ class Jp2kDecoderAsyncTest {
 
     @Test
     fun testGetSize_NoDataCached() {
-        val jsonError = """{"errorCode": -10, "errorMessage": "No data cached"}"""
+        val jsonError = """{"errorCode": ${Jp2kError.CacheDataMissing.code}, "errorMessage": "No data cached"}"""
 
         doAnswer { invocation ->
             val script = invocation.arguments[0] as String
             if (script.contains("base64ToBytes")) {
-                TestListenableFuture("1")
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
             } else if (script.contains("getSizeWithCache")) {
                 TestListenableFuture(jsonError)
             } else {
-                TestListenableFuture("1")
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
             }
         }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
 

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
@@ -91,7 +91,7 @@ class Jp2kDecoderTest {
     }
 
     @Test
-    fun testInitWithData_Success() = runTest {
+    fun testPrecache_Success() = runTest {
         // Mock evaluateJavaScriptAsync for WASM load (returns "1") and setData (returns "1")
         doAnswer { invocation ->
             // Use simple string matching logic to return appropriate result
@@ -101,8 +101,9 @@ class Jp2kDecoderTest {
         }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
 
         val decoder = Jp2kDecoder(coroutineDispatcher = testDispatcher)
+        decoder.init(context)
         val data = ByteArray(10)
-        decoder.init(context, data)
+        decoder.precache(data)
 
         // Verify setData was called
         verify(isolate, Mockito.atLeastOnce()).evaluateJavaScriptAsync(contains("setData"))
@@ -127,7 +128,8 @@ class Jp2kDecoderTest {
 
         val decoder = Jp2kDecoder(coroutineDispatcher = testDispatcher)
         val data = ByteArray(10)
-        decoder.init(context, data)
+        decoder.init(context)
+        decoder.precache(data)
         val size = decoder.getSize()
 
         assertEquals(100, size.width)
@@ -152,6 +154,8 @@ class Jp2kDecoderTest {
         val decoder = Jp2kDecoder(coroutineDispatcher = testDispatcher)
         // Init WITHOUT data
         decoder.init(context)
+
+        // Do not call precache
 
         try {
             decoder.getSize()

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
@@ -1,0 +1,163 @@
+package dev.keiji.jp2k
+
+import android.content.Context
+import android.content.res.AssetManager
+import androidx.javascriptengine.JavaScriptIsolate
+import androidx.javascriptengine.JavaScriptSandbox
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.contains
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.whenever
+import java.io.ByteArrayInputStream
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+@ExperimentalCoroutinesApi
+class Jp2kDecoderTest {
+
+    @Mock
+    lateinit var context: Context
+
+    @Mock
+    lateinit var assetManager: AssetManager
+
+    @Mock
+    lateinit var sandbox: JavaScriptSandbox
+
+    @Mock
+    lateinit var isolate: JavaScriptIsolate
+
+    private lateinit var mockJp2kSandbox: MockedStatic<Jp2kSandbox>
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    class TestListenableFuture<T>(private val result: T) : ListenableFuture<T> {
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
+        override fun isCancelled(): Boolean = false
+        override fun isDone(): Boolean = true
+        override fun get(): T = result
+        override fun get(timeout: Long, unit: TimeUnit?): T = result
+        override fun addListener(listener: Runnable, executor: Executor) {
+            listener.run()
+        }
+    }
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+
+        whenever(context.assets).thenReturn(assetManager)
+        whenever(assetManager.open(any<String>())).thenReturn(ByteArrayInputStream(ByteArray(0)))
+
+        mockJp2kSandbox = mockStatic(Jp2kSandbox::class.java)
+
+        mockJp2kSandbox.`when`<ListenableFuture<JavaScriptSandbox>> {
+            Jp2kSandbox.get(any<Context>())
+        }.thenReturn(TestListenableFuture(sandbox))
+
+        mockJp2kSandbox.`when`<JavaScriptIsolate> {
+            Jp2kSandbox.createIsolate(any(), any(), any())
+        }.thenReturn(isolate)
+
+        // Mock sandbox feature support
+        whenever(sandbox.isFeatureSupported(any<String>())).thenReturn(true)
+    }
+
+    @After
+    fun tearDown() {
+        mockJp2kSandbox.close()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun testInitWithData_Success() = runTest {
+        // Mock evaluateJavaScriptAsync for WASM load (returns "1") and setData (returns "1")
+        doAnswer { invocation ->
+            // Use simple string matching logic to return appropriate result
+            val script = invocation.arguments[0] as String
+            // Default return "1" for all async calls in this test (loadWasm, setData)
+            TestListenableFuture("1")
+        }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        val decoder = Jp2kDecoder(coroutineDispatcher = testDispatcher)
+        val data = ByteArray(10)
+        decoder.init(context, data)
+
+        // Verify setData was called
+        verify(isolate, Mockito.atLeastOnce()).evaluateJavaScriptAsync(contains("setData"))
+    }
+
+    @Test
+    fun testGetSize_Success() = runTest {
+        val jsonSize = """{"width": 100, "height": 200}"""
+
+        doAnswer { invocation ->
+            val script = invocation.arguments[0] as String
+            if (script.contains("base64ToBytes")) {
+                TestListenableFuture("1") // WASM load
+            } else if (script.contains("setData")) {
+                TestListenableFuture("1") // setData
+            } else if (script.contains("getSizeWithCache")) {
+                TestListenableFuture(jsonSize) // getSizeWithCache
+            } else {
+                TestListenableFuture("1") // Default
+            }
+        }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        val decoder = Jp2kDecoder(coroutineDispatcher = testDispatcher)
+        val data = ByteArray(10)
+        decoder.init(context, data)
+        val size = decoder.getSize()
+
+        assertEquals(100, size.width)
+        assertEquals(200, size.height)
+    }
+
+    @Test
+    fun testGetSize_NoDataCached() = runTest {
+        val jsonError = """{"errorCode": -10, "errorMessage": "No data cached"}"""
+
+        doAnswer { invocation ->
+            val script = invocation.arguments[0] as String
+            if (script.contains("base64ToBytes")) {
+                TestListenableFuture("1") // WASM load
+            } else if (script.contains("getSizeWithCache")) {
+                TestListenableFuture(jsonError) // getSizeWithCache
+            } else {
+                TestListenableFuture("1")
+            }
+        }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        val decoder = Jp2kDecoder(coroutineDispatcher = testDispatcher)
+        // Init WITHOUT data
+        decoder.init(context)
+
+        try {
+            decoder.getSize()
+            fail("Should throw IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertEquals("No data cached", e.message)
+        }
+    }
+}

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
@@ -97,7 +97,7 @@ class Jp2kDecoderTest {
             // Use simple string matching logic to return appropriate result
             val script = invocation.arguments[0] as String
             // Default return "1" for all async calls in this test (loadWasm, setData)
-            TestListenableFuture("1")
+            TestListenableFuture(INTERNAL_RESULT_SUCCESS)
         }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
 
         val decoder = Jp2kDecoder(coroutineDispatcher = testDispatcher)
@@ -115,13 +115,13 @@ class Jp2kDecoderTest {
         doAnswer { invocation ->
             val script = invocation.arguments[0] as String
             if (script.contains("base64ToBytes")) {
-                TestListenableFuture("1") // WASM load
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS) // WASM load
             } else if (script.contains("setData")) {
-                TestListenableFuture("1") // setData
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS) // setData
             } else if (script.contains("getSizeWithCache")) {
                 TestListenableFuture(jsonSize) // getSizeWithCache
             } else {
-                TestListenableFuture("1") // Default
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS) // Default
             }
         }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
 
@@ -136,16 +136,16 @@ class Jp2kDecoderTest {
 
     @Test
     fun testGetSize_NoDataCached() = runTest {
-        val jsonError = """{"errorCode": -10, "errorMessage": "No data cached"}"""
+        val jsonError = """{"errorCode": ${Jp2kError.CacheDataMissing.code}, "errorMessage": "No data cached"}"""
 
         doAnswer { invocation ->
             val script = invocation.arguments[0] as String
             if (script.contains("base64ToBytes")) {
-                TestListenableFuture("1") // WASM load
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS) // WASM load
             } else if (script.contains("getSizeWithCache")) {
                 TestListenableFuture(jsonError) // getSizeWithCache
             } else {
-                TestListenableFuture("1")
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
             }
         }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
 

--- a/android/lib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/android/lib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/android/lib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/android/lib/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Implemented cached data support for Jp2kDecoder and Jp2kDecoderAsync to improve performance by reducing data transfer overhead between Android and JavaScript Sandbox. Added init overloads that accept image data, and parameterless getSize/decodeImage methods that utilize the cached data.

---
*PR created automatically by Jules for task [15137727227836254244](https://jules.google.com/task/15137727227836254244) started by @keiji*