### PR TITLE
Implement partial decoding for JPEG2000

### DIFF
--- a/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Constants.kt
@@ -143,7 +143,7 @@ internal val SCRIPT_DEFINE_SET_DATA = """
 """
 
 internal val SCRIPT_DEFINE_DECODE_J2K = """
-            globalThis.internalDecodeJ2K = function(encodedBuffer, maxPixels, maxHeapSize, colorFormat, measureTimes) {
+            globalThis.internalDecodeJ2K = function(encodedBuffer, maxPixels, maxHeapSize, colorFormat, measureTimes, x0, y0, x1, y1) {
                 const now = function() {
                     return (typeof performance !== 'undefined' && performance.now) ? performance.now() : Date.now();
                 };
@@ -169,7 +169,7 @@ internal val SCRIPT_DEFINE_DECODE_J2K = """
                     }
 
                     // Call decodeToBmp
-                    const bmpPtr = exports.decodeToBmp(inputPtr, encodedBuffer.length, maxPixels, maxHeapSize, colorFormat);
+                    const bmpPtr = exports.decodeToBmp(inputPtr, encodedBuffer.length, maxPixels, maxHeapSize, colorFormat, x0, y0, x1, y1);
 
                     if (measureTimes) {
                          timeAfterDecode = now();
@@ -210,20 +210,20 @@ internal val SCRIPT_DEFINE_DECODE_J2K = """
                 }
             };
 
-            globalThis.decodeJ2K = function(dataBase64String, maxPixels, maxHeapSize, colorFormat, measureTimes) {
+            globalThis.decodeJ2K = function(dataBase64String, maxPixels, maxHeapSize, colorFormat, measureTimes, x0, y0, x1, y1) {
                 try {
                     const encodedBuffer = globalThis.base64ToBytes(dataBase64String);
-                    return globalThis.internalDecodeJ2K(encodedBuffer, maxPixels, maxHeapSize, colorFormat, measureTimes);
+                    return globalThis.internalDecodeJ2K(encodedBuffer, maxPixels, maxHeapSize, colorFormat, measureTimes, x0, y0, x1, y1);
                 } catch (e) {
                     return JSON.stringify({ errorCode: ${Jp2kError.Unknown.code}, errorMessage: e.toString() });
                 }
             };
 
-            globalThis.decodeJ2KWithCache = function(maxPixels, maxHeapSize, colorFormat, measureTimes) {
+            globalThis.decodeJ2KWithCache = function(maxPixels, maxHeapSize, colorFormat, measureTimes, x0, y0, x1, y1) {
                 if (!globalThis.j2kData) {
                     return JSON.stringify({ errorCode: ${Jp2kError.CacheDataMissing.code}, errorMessage: "No data cached" });
                 }
-                return globalThis.internalDecodeJ2K(globalThis.j2kData, maxPixels, maxHeapSize, colorFormat, measureTimes);
+                return globalThis.internalDecodeJ2K(globalThis.j2kData, maxPixels, maxHeapSize, colorFormat, measureTimes, x0, y0, x1, y1);
             };
 
             globalThis.getMemoryUsage = function() {

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Rect
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.javascriptengine.JavaScriptIsolate
@@ -324,6 +325,22 @@ class Jp2kDecoder(
     }
 
     /**
+     * Decodes a specific region of a JPEG 2000 image.
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param region The region to decode.
+     * @param colorFormat The desired output color format. Defaults to [ColorFormat.ARGB8888].
+     * @return The decoded [Bitmap].
+     */
+    suspend fun decodeImage(
+        j2kData: ByteArray,
+        region: Rect,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+    ): Bitmap {
+        return decodeImage(j2kData, region.left, region.top, region.right, region.bottom, colorFormat)
+    }
+
+    /**
      * Decodes a JPEG 2000 image using cached data.
      *
      * @param colorFormat The desired output color format. Defaults to [ColorFormat.ARGB8888].
@@ -361,6 +378,20 @@ class Jp2kDecoder(
             "globalThis.decodeJ2KWithCache(${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes, $left, $top, $right, $bottom);"
 
         return executeDecodeImage(script, colorFormat)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image using cached data.
+     *
+     * @param region The region to decode.
+     * @param colorFormat The desired output color format. Defaults to [ColorFormat.ARGB8888].
+     * @return The decoded [Bitmap].
+     */
+    suspend fun decodeImage(
+        region: Rect,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+    ): Bitmap {
+        return decodeImage(region.left, region.top, region.right, region.bottom, colorFormat)
     }
 
     private suspend fun executeDecodeImage(

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Rect
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.javascriptengine.JavaScriptIsolate
@@ -399,6 +400,34 @@ class Jp2kDecoderAsync(
     }
 
     /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously using cached data.
+     *
+     * @param region The region to decode.
+     * @param colorFormat The desired output color format.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        region: Rect,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(region.left, region.top, region.right, region.bottom, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously using cached data with default color format (ARGB 8888).
+     *
+     * @param region The region to decode.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        region: Rect,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(region, ColorFormat.ARGB8888, callback)
+    }
+
+    /**
      * Decodes a JPEG 2000 image asynchronously.
      *
      * @param j2kData The raw byte array of the JPEG 2000 image.
@@ -479,6 +508,38 @@ class Jp2kDecoderAsync(
         callback: Callback<Bitmap>
     ) {
         decodeImage(j2kData, left, top, right, bottom, ColorFormat.ARGB8888, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously.
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param region The region to decode.
+     * @param colorFormat The desired output color format.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        j2kData: ByteArray,
+        region: Rect,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(j2kData, region.left, region.top, region.right, region.bottom, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously with default color format (ARGB 8888).
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param region The region to decode.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        j2kData: ByteArray,
+        region: Rect,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(j2kData, region, ColorFormat.ARGB8888, callback)
     }
 
     private fun executeDecodeImage(

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -351,8 +351,51 @@ class Jp2kDecoderAsync(
     fun decodeImage(colorFormat: ColorFormat = ColorFormat.ARGB8888, callback: Callback<Bitmap>) {
         val measureTimes = config.logLevel != null
         val script =
-            "globalThis.decodeJ2KWithCache(${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes);"
+            "globalThis.decodeJ2KWithCache(${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes, 0, 0, 0, 0);"
         executeDecodeImage(script, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously using cached data.
+     *
+     * @param left The left coordinate of the region.
+     * @param top The top coordinate of the region.
+     * @param right The right coordinate of the region.
+     * @param bottom The bottom coordinate of the region.
+     * @param colorFormat The desired output color format.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+        callback: Callback<Bitmap>
+    ) {
+        val measureTimes = config.logLevel != null
+        val script =
+            "globalThis.decodeJ2KWithCache(${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes, $left, $top, $right, $bottom);"
+        executeDecodeImage(script, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously using cached data with default color format (ARGB 8888).
+     *
+     * @param left The left coordinate of the region.
+     * @param top The top coordinate of the region.
+     * @param right The right coordinate of the region.
+     * @param bottom The bottom coordinate of the region.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(left, top, right, bottom, ColorFormat.ARGB8888, callback)
     }
 
     /**
@@ -377,9 +420,65 @@ class Jp2kDecoderAsync(
         val measureTimes = config.logLevel != null
         val dataBase64String = Base64.getEncoder().encodeToString(j2kData)
         val script =
-            "globalThis.decodeJ2K('$dataBase64String', ${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes);"
+            "globalThis.decodeJ2K('$dataBase64String', ${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes, 0, 0, 0, 0);"
 
         executeDecodeImage(script, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously.
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param left The left coordinate of the region.
+     * @param top The top coordinate of the region.
+     * @param right The right coordinate of the region.
+     * @param bottom The bottom coordinate of the region.
+     * @param colorFormat The desired output color format.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        j2kData: ByteArray,
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+        callback: Callback<Bitmap>
+    ) {
+        log(Log.INFO, "Input data length: ${j2kData.size}")
+
+        if (j2kData.size < MIN_INPUT_SIZE) {
+            callback.onError(IllegalArgumentException("Input data is too short"))
+            return
+        }
+
+        val measureTimes = config.logLevel != null
+        val dataBase64String = Base64.getEncoder().encodeToString(j2kData)
+        val script =
+            "globalThis.decodeJ2K('$dataBase64String', ${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes, $left, $top, $right, $bottom);"
+
+        executeDecodeImage(script, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously with default color format (ARGB 8888).
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param left The left coordinate of the region.
+     * @param top The top coordinate of the region.
+     * @param right The right coordinate of the region.
+     * @param bottom The bottom coordinate of the region.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        j2kData: ByteArray,
+        left: Int,
+        top: Int,
+        right: Int,
+        bottom: Int,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(j2kData, left, top, right, bottom, ColorFormat.ARGB8888, callback)
     }
 
     private fun executeDecodeImage(
@@ -436,6 +535,11 @@ class Jp2kDecoderAsync(
                         val errorMessage =
                             if (root.has("errorMessage")) root.getString("errorMessage") else null
                         log(Log.ERROR, "Error: $error, Message: $errorMessage")
+
+                        if (error == Jp2kError.RegionOutOfBounds) {
+                            throw RegionOutOfBoundsException(errorMessage)
+                        }
+
                         throw Jp2kException(error, errorMessage)
                     } else if (root.has("error")) {
                         val errorMsg = root.getString("error")

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kError.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kError.kt
@@ -21,6 +21,12 @@ enum class Jp2kError(val code: Int) {
     /** Generic decoding error. */
     Decode(-4),
 
+    /** Decoder setup error. */
+    DecoderSetup(-5),
+
+    /** Region out of bounds error. */
+    RegionOutOfBounds(-6),
+
     /** Cache data missing error. */
     CacheDataMissing(-10),
 

--- a/android/lib/src/main/java/dev/keiji/jp2k/RegionOutOfBoundsException.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/RegionOutOfBoundsException.kt
@@ -1,0 +1,6 @@
+package dev.keiji.jp2k
+
+/**
+ * Exception thrown when the requested decoding region is out of the image bounds.
+ */
+class RegionOutOfBoundsException(message: String? = null) : IllegalArgumentException(message)

--- a/test/stubs.c
+++ b/test/stubs.c
@@ -38,6 +38,9 @@ OPJ_BOOL opj_read_header(opj_stream_t *p_stream, opj_codec_t *p_codec, opj_image
     }
     return OPJ_FALSE;
 }
+OPJ_BOOL opj_set_decode_area(opj_codec_t *p_codec, opj_image_t* p_image, OPJ_INT32 p_start_x, OPJ_INT32 p_start_y, OPJ_INT32 p_end_x, OPJ_INT32 p_end_y) {
+    return OPJ_TRUE;
+}
 void opj_image_destroy(opj_image_t *image) {
     if (image) {
         if (image->comps) {


### PR DESCRIPTION
Implemented partial decoding functionality allowing users to decode specific regions (LTRB) of a JPEG2000 image. This includes:
- Native C implementation using `opj_set_decode_area` with robust bounds checking.
- New Exception class `RegionOutOfBoundsException` inheriting from `IllegalArgumentException`.
- Kotlin API updates for both Coroutine and Async implementations.
- Comprehensive C unit tests for the new logic.

---
*PR created automatically by Jules for task [11967025153612446694](https://jules.google.com/task/11967025153612446694) started by @keiji*