### PR TITLE
Support ratio-based region decoding (0.0-1.0)

### DIFF
--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -364,11 +364,7 @@ class Jp2kDecoder(
         if (j2kData.size < MIN_INPUT_SIZE) {
             throw IllegalArgumentException("Input data is too short")
         }
-        if (left < 0.0f || left > 1.0f || top < 0.0f || top > 1.0f ||
-            right < 0.0f || right > 1.0f || bottom < 0.0f || bottom > 1.0f
-        ) {
-            throw IllegalArgumentException("Ratio must be 0.0 - 1.0")
-        }
+        validateRatio(left, top, right, bottom)
 
         val measureTimes = config.logLevel != null
         val dataBase64String = Base64.getEncoder().encodeToString(j2kData)
@@ -449,17 +445,21 @@ class Jp2kDecoder(
         bottom: Float,
         colorFormat: ColorFormat = ColorFormat.ARGB8888,
     ): Bitmap {
-        if (left < 0.0f || left > 1.0f || top < 0.0f || top > 1.0f ||
-            right < 0.0f || right > 1.0f || bottom < 0.0f || bottom > 1.0f
-        ) {
-            throw IllegalArgumentException("Ratio must be 0.0 - 1.0")
-        }
+        validateRatio(left, top, right, bottom)
 
         val measureTimes = config.logLevel != null
         val script =
             "globalThis.decodeJ2KWithCacheRatio(${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes, $left, $top, $right, $bottom);"
 
         return executeDecodeImage(script, colorFormat)
+    }
+
+    private fun validateRatio(left: Float, top: Float, right: Float, bottom: Float) {
+        if (left < 0.0f || left > 1.0f || top < 0.0f || top > 1.0f ||
+            right < 0.0f || right > 1.0f || bottom < 0.0f || bottom > 1.0f
+        ) {
+            throw IllegalArgumentException("Ratio must be 0.0 - 1.0")
+        }
     }
 
     private suspend fun executeDecodeImage(

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -428,6 +428,56 @@ class Jp2kDecoderAsync(
     }
 
     /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously using cached data.
+     *
+     * @param left The left coordinate ratio (0.0 - 1.0).
+     * @param top The top coordinate ratio (0.0 - 1.0).
+     * @param right The right coordinate ratio (0.0 - 1.0).
+     * @param bottom The bottom coordinate ratio (0.0 - 1.0).
+     * @param colorFormat The desired output color format.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+        callback: Callback<Bitmap>
+    ) {
+        if (left < 0.0f || left > 1.0f || top < 0.0f || top > 1.0f ||
+            right < 0.0f || right > 1.0f || bottom < 0.0f || bottom > 1.0f
+        ) {
+            callback.onError(IllegalArgumentException("Ratio must be 0.0 - 1.0"))
+            return
+        }
+
+        val measureTimes = config.logLevel != null
+        val script =
+            "globalThis.decodeJ2KWithCacheRatio(${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes, $left, $top, $right, $bottom);"
+        executeDecodeImage(script, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously using cached data with default color format (ARGB 8888).
+     *
+     * @param left The left coordinate ratio (0.0 - 1.0).
+     * @param top The top coordinate ratio (0.0 - 1.0).
+     * @param right The right coordinate ratio (0.0 - 1.0).
+     * @param bottom The bottom coordinate ratio (0.0 - 1.0).
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(left, top, right, bottom, ColorFormat.ARGB8888, callback)
+    }
+
+    /**
      * Decodes a JPEG 2000 image asynchronously.
      *
      * @param j2kData The raw byte array of the JPEG 2000 image.
@@ -540,6 +590,68 @@ class Jp2kDecoderAsync(
         callback: Callback<Bitmap>
     ) {
         decodeImage(j2kData, region, ColorFormat.ARGB8888, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously.
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param left The left coordinate ratio (0.0 - 1.0).
+     * @param top The top coordinate ratio (0.0 - 1.0).
+     * @param right The right coordinate ratio (0.0 - 1.0).
+     * @param bottom The bottom coordinate ratio (0.0 - 1.0).
+     * @param colorFormat The desired output color format.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        j2kData: ByteArray,
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+        callback: Callback<Bitmap>
+    ) {
+        log(Log.INFO, "Input data length: ${j2kData.size}")
+
+        if (j2kData.size < MIN_INPUT_SIZE) {
+            callback.onError(IllegalArgumentException("Input data is too short"))
+            return
+        }
+        if (left < 0.0f || left > 1.0f || top < 0.0f || top > 1.0f ||
+            right < 0.0f || right > 1.0f || bottom < 0.0f || bottom > 1.0f
+        ) {
+            callback.onError(IllegalArgumentException("Ratio must be 0.0 - 1.0"))
+            return
+        }
+
+        val measureTimes = config.logLevel != null
+        val dataBase64String = Base64.getEncoder().encodeToString(j2kData)
+        val script =
+            "globalThis.decodeJ2KRatio('$dataBase64String', ${config.maxPixels}, ${config.maxHeapSizeBytes}, ${colorFormat.id}, $measureTimes, $left, $top, $right, $bottom);"
+
+        executeDecodeImage(script, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously with default color format (ARGB 8888).
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param left The left coordinate ratio (0.0 - 1.0).
+     * @param top The top coordinate ratio (0.0 - 1.0).
+     * @param right The right coordinate ratio (0.0 - 1.0).
+     * @param bottom The bottom coordinate ratio (0.0 - 1.0).
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        j2kData: ByteArray,
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(j2kData, left, top, right, bottom, ColorFormat.ARGB8888, callback)
     }
 
     private fun executeDecodeImage(

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -445,10 +445,7 @@ class Jp2kDecoderAsync(
         colorFormat: ColorFormat = ColorFormat.ARGB8888,
         callback: Callback<Bitmap>
     ) {
-        if (left < 0.0f || left > 1.0f || top < 0.0f || top > 1.0f ||
-            right < 0.0f || right > 1.0f || bottom < 0.0f || bottom > 1.0f
-        ) {
-            callback.onError(IllegalArgumentException("Ratio must be 0.0 - 1.0"))
+        if (!validateRatio(left, top, right, bottom, callback)) {
             return
         }
 
@@ -618,10 +615,7 @@ class Jp2kDecoderAsync(
             callback.onError(IllegalArgumentException("Input data is too short"))
             return
         }
-        if (left < 0.0f || left > 1.0f || top < 0.0f || top > 1.0f ||
-            right < 0.0f || right > 1.0f || bottom < 0.0f || bottom > 1.0f
-        ) {
-            callback.onError(IllegalArgumentException("Ratio must be 0.0 - 1.0"))
+        if (!validateRatio(left, top, right, bottom, callback)) {
             return
         }
 
@@ -652,6 +646,22 @@ class Jp2kDecoderAsync(
         callback: Callback<Bitmap>
     ) {
         decodeImage(j2kData, left, top, right, bottom, ColorFormat.ARGB8888, callback)
+    }
+
+    private fun validateRatio(
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float,
+        callback: Callback<Bitmap>
+    ): Boolean {
+        if (left < 0.0f || left > 1.0f || top < 0.0f || top > 1.0f ||
+            right < 0.0f || right > 1.0f || bottom < 0.0f || bottom > 1.0f
+        ) {
+            callback.onError(IllegalArgumentException("Ratio must be 0.0 - 1.0"))
+            return false
+        }
+        return true
     }
 
     private fun executeDecodeImage(


### PR DESCRIPTION
This PR introduces support for decoding specific regions of a JPEG 2000 image using ratio-based coordinates (0.0 to 1.0) instead of absolute pixels. This allows consumers to decode relative regions without pre-calculating pixel dimensions.

Key changes:
1.  **Native (C/WASM):**
    *   Modified `wrapper.c` to include `decodeToBmpWithRatio`.
    *   Refactored `decode_internal` to accept `double` coordinates and a `use_ratio` flag, performing the conversion from ratio to pixels using the image header dimensions directly within the decoder logic.
2.  **Android (Kotlin):**
    *   Added `decodeImage(left: Float, top: Float, right: Float, bottom: Float, ...)` overloads to `Jp2kDecoder` and `Jp2kDecoderAsync`.
    *   Updated `Constants.kt` with new JS bridge functions to pass float arguments to WASM.
3.  **Tests:**
    *   Added unit tests in `Jp2kDecoderTest.kt` and `Jp2kDecoderAsyncTest.kt`.
    *   Added C-level unit tests in `test_wrapper.c` covering ratio decoding scenarios.

---
*PR created automatically by Jules for task [3421974915147378309](https://jules.google.com/task/3421974915147378309) started by @keiji*