### PR TITLE
Improve test coverage for C wrapper and Android library

### DIFF
--- a/test/stubs.c
+++ b/test/stubs.c
@@ -63,6 +63,16 @@ OPJ_BOOL opj_decode(opj_codec_t *p_decompressor, opj_stream_t *p_stream, opj_ima
         uint32_t h = p_image->y1 - p_image->y0;
         for (uint32_t i = 0; i < p_image->numcomps; i++) {
              p_image->comps[i].data = (OPJ_INT32*)malloc(w * h * sizeof(OPJ_INT32));
+             if (!p_image->comps[i].data) {
+                 // Clean up on allocation failure
+                 for (uint32_t k = 0; k < i; k++) {
+                     if (p_image->comps[k].data) {
+                         free(p_image->comps[k].data);
+                         p_image->comps[k].data = NULL;
+                     }
+                 }
+                 return OPJ_FALSE;
+             }
              // Fill with dummy data (e.g. solid white/opaque)
              // 255 for all channels
              for (uint32_t j = 0; j < w * h; j++) {

--- a/test/stubs.c
+++ b/test/stubs.c
@@ -1,6 +1,7 @@
 #include <openjpeg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 // Stubs for functions used in wrapper.c but not needed for testing convert_to_bmp
 
@@ -10,6 +11,7 @@ uint32_t stub_height = 0;
 
 int stub_should_decompress_create_succeed = 1;
 int stub_should_setup_succeed = 1;
+int stub_should_decode_succeed = 0;
 
 opj_codec_t* opj_create_decompress(OPJ_CODEC_FORMAT format) {
     if (stub_should_decompress_create_succeed) {
@@ -34,6 +36,8 @@ OPJ_BOOL opj_read_header(opj_stream_t *p_stream, opj_codec_t *p_codec, opj_image
         (*p_image)->y0 = 0;
         (*p_image)->x1 = stub_width;
         (*p_image)->y1 = stub_height;
+        (*p_image)->numcomps = 4;
+        (*p_image)->comps = (opj_image_comp_t*)calloc(4, sizeof(opj_image_comp_t));
         return OPJ_TRUE;
     }
     return OPJ_FALSE;
@@ -52,6 +56,22 @@ void opj_image_destroy(opj_image_t *image) {
         free(image);
     }
 }
-OPJ_BOOL opj_decode(opj_codec_t *p_decompressor, opj_stream_t *p_stream, opj_image_t *p_image) { return OPJ_FALSE; }
+OPJ_BOOL opj_decode(opj_codec_t *p_decompressor, opj_stream_t *p_stream, opj_image_t *p_image) {
+    if (stub_should_decode_succeed) {
+        // Allocate data for comps
+        uint32_t w = p_image->x1 - p_image->x0;
+        uint32_t h = p_image->y1 - p_image->y0;
+        for (uint32_t i = 0; i < p_image->numcomps; i++) {
+             p_image->comps[i].data = (OPJ_INT32*)malloc(w * h * sizeof(OPJ_INT32));
+             // Fill with dummy data (e.g. solid white/opaque)
+             // 255 for all channels
+             for (uint32_t j = 0; j < w * h; j++) {
+                 p_image->comps[i].data[j] = 255;
+             }
+        }
+        return OPJ_TRUE;
+    }
+    return OPJ_FALSE;
+}
 void opj_stream_destroy(opj_stream_t* p_stream) { if(p_stream) free(p_stream); }
 void opj_destroy_codec(opj_codec_t * p_codec) { if(p_codec) free(p_codec); }


### PR DESCRIPTION
This PR improves test coverage by adding missing test cases for the C/Native wrapper and the Android Kotlin library.

Changes:
1.  **C/Native (`test/`):**
    *   Updated `stubs.c` to allow simulating a successful `opj_decode` operation by populating component data.
    *   Added `test_jp2_signature` to `test_wrapper.c` to verify JP2 format detection.
    *   Added `test_pixel_limit` to verify `ERR_PIXEL_DATA_SIZE` handling.
    *   Added `test_full_decode_success` to verify the full `decodeToBmp` path.

2.  **Android (`android/lib/src/test/`):**
    *   Added `testInit_Error`, `testDecodeImage_DecodeError`, and `testDecodeImage_RegionOutOfBounds` to `Jp2kDecoderAsyncTest.kt`.
    *   Added equivalent tests to `Jp2kDecoderTest.kt` (Coroutines version).

These changes ensure that error handling paths and specific logic branches (like JP2 detection and WASM interaction failures) are properly tested.

---
*PR created automatically by Jules for task [16676193805102107471](https://jules.google.com/task/16676193805102107471) started by @keiji*