### PR TITLE
Increase Android Test Coverage

### DIFF
--- a/android/lib/src/test/java/dev/keiji/jp2k/ExceptionTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/ExceptionTest.kt
@@ -1,0 +1,35 @@
+package dev.keiji.jp2k
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ExceptionTest {
+
+    @Test
+    fun testRegionOutOfBoundsException() {
+        val exception = RegionOutOfBoundsException("Message")
+        assertEquals("Message", exception.message)
+
+        val exceptionNull = RegionOutOfBoundsException()
+        assertNull(exceptionNull.message)
+    }
+
+    @Test
+    fun testJp2kError() {
+        assertEquals(Jp2kError.None, Jp2kError.fromInt(0))
+        assertEquals(Jp2kError.Header, Jp2kError.fromInt(-1))
+        assertEquals(Jp2kError.Unknown, Jp2kError.fromInt(-999))
+    }
+
+    @Test
+    fun testJp2kException() {
+        val exception = Jp2kException(Jp2kError.Header)
+        assertEquals("Error code: -1", exception.message)
+        assertEquals(Jp2kError.Header, exception.error)
+
+        val exceptionWithMsg = Jp2kException(Jp2kError.Decode, "Custom Message")
+        assertEquals("Custom Message", exceptionWithMsg.message)
+        assertEquals(Jp2kError.Decode, exceptionWithMsg.error)
+    }
+}

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncCoverageTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncCoverageTest.kt
@@ -47,17 +47,6 @@ class Jp2kDecoderAsyncCoverageTest {
     private lateinit var mockBitmapFactory: MockedStatic<BitmapFactory>
     private lateinit var mockLog: MockedStatic<android.util.Log>
 
-    class TestListenableFuture<T>(private val result: T) : ListenableFuture<T> {
-        override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
-        override fun isCancelled(): Boolean = false
-        override fun isDone(): Boolean = true
-        override fun get(): T = result
-        override fun get(timeout: Long, unit: TimeUnit?): T = result
-        override fun addListener(listener: Runnable, executor: Executor) {
-            listener.run()
-        }
-    }
-
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kOverloadsTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kOverloadsTest.kt
@@ -1,0 +1,161 @@
+package dev.keiji.jp2k
+
+import android.content.Context
+import android.content.res.AssetManager
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Rect
+import androidx.javascriptengine.JavaScriptIsolate
+import androidx.javascriptengine.JavaScriptSandbox
+import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.Mockito.mockStatic
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.whenever
+import java.io.ByteArrayInputStream
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+@ExperimentalCoroutinesApi
+class Jp2kOverloadsTest {
+
+    @Mock
+    lateinit var context: Context
+    @Mock
+    lateinit var assetManager: AssetManager
+    @Mock
+    lateinit var sandbox: JavaScriptSandbox
+    @Mock
+    lateinit var isolate: JavaScriptIsolate
+
+    private lateinit var mockJp2kSandbox: MockedStatic<Jp2kSandbox>
+    private lateinit var mockBitmapFactory: MockedStatic<BitmapFactory>
+    private lateinit var mockLog: MockedStatic<android.util.Log>
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    class TestListenableFuture<T>(private val result: T) : ListenableFuture<T> {
+        override fun cancel(mayInterruptIfRunning: Boolean) = false
+        override fun isCancelled() = false
+        override fun isDone() = true
+        override fun get() = result
+        override fun get(timeout: Long, unit: TimeUnit?) = result
+        override fun addListener(listener: Runnable, executor: Executor) { listener.run() }
+    }
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+
+        whenever(context.assets).thenReturn(assetManager)
+        whenever(assetManager.open(any<String>())).thenReturn(ByteArrayInputStream(ByteArray(0)))
+
+        mockJp2kSandbox = mockStatic(Jp2kSandbox::class.java)
+        mockJp2kSandbox.`when`<ListenableFuture<JavaScriptSandbox>> { Jp2kSandbox.get(any<Context>()) }
+            .thenReturn(TestListenableFuture(sandbox))
+        mockJp2kSandbox.`when`<JavaScriptIsolate> { Jp2kSandbox.createIsolate(any(), any(), any()) }
+            .thenReturn(isolate)
+        whenever(sandbox.isFeatureSupported(any<String>())).thenReturn(true)
+
+        mockBitmapFactory = mockStatic(BitmapFactory::class.java)
+        mockBitmapFactory.`when`<Bitmap> { BitmapFactory.decodeByteArray(any(), any(), any(), any()) }
+            .thenReturn(Mockito.mock(Bitmap::class.java))
+
+        mockLog = mockStatic(android.util.Log::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        mockJp2kSandbox.close()
+        mockBitmapFactory.close()
+        mockLog.close()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun testJp2kDecoderAsyncOverloads() {
+        val directExecutor = Executor { it.run() }
+        val config = Config(logLevel = android.util.Log.VERBOSE)
+        val decoder = Jp2kDecoderAsync(backgroundExecutor = directExecutor, config = config)
+
+        doAnswer { TestListenableFuture(INTERNAL_RESULT_SUCCESS) }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        decoder.init(context, org.mockito.kotlin.mock())
+        decoder.precache(ByteArray(12), org.mockito.kotlin.mock())
+
+        val callback = org.mockito.kotlin.mock<Callback<Bitmap>>()
+        val data = ByteArray(12)
+        val rect = Rect(0, 0, 10, 10)
+
+        // Prepare mock for decode execution
+        val jsonBmp = """{"bmp": "AQID"}"""
+        doAnswer { TestListenableFuture(jsonBmp) }.whenever(isolate).evaluateJavaScriptAsync(org.mockito.ArgumentMatchers.contains("decodeJ2K"))
+
+        // Cached overloads
+        decoder.decodeImage(ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(0, 0, 10, 10, ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(0, 0, 10, 10, callback)
+        decoder.decodeImage(rect, ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(rect, callback)
+        decoder.decodeImage(0f, 0f, 0.5f, 0.5f, ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(0f, 0f, 0.5f, 0.5f, callback)
+
+        // Data overloads
+        decoder.decodeImage(data, ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(data, 0, 0, 10, 10, ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(data, 0, 0, 10, 10, callback)
+        decoder.decodeImage(data, rect, ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(data, rect, callback)
+        decoder.decodeImage(data, 0f, 0f, 0.5f, 0.5f, ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(data, 0f, 0f, 0.5f, 0.5f, callback)
+
+        // Just verify called many times
+        verify(isolate, Mockito.atLeast(14)).evaluateJavaScriptAsync(any<String>())
+    }
+
+    @Test
+    fun testJp2kDecoderOverloads() = runTest {
+        val config = Config(logLevel = android.util.Log.VERBOSE)
+        // Use testDispatcher
+        val decoder = Jp2kDecoder(config = config, coroutineDispatcher = testDispatcher)
+
+        doAnswer { TestListenableFuture(INTERNAL_RESULT_SUCCESS) }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        decoder.init(context)
+        decoder.precache(ByteArray(12))
+
+        val data = ByteArray(12)
+        val rect = Rect(0, 0, 10, 10)
+        val jsonBmp = """{"bmp": "AQID"}"""
+        doAnswer { TestListenableFuture(jsonBmp) }.whenever(isolate).evaluateJavaScriptAsync(org.mockito.ArgumentMatchers.contains("decodeJ2K"))
+
+        // Cached overloads
+        decoder.decodeImage(ColorFormat.ARGB8888)
+        decoder.decodeImage(0, 0, 10, 10, ColorFormat.ARGB8888)
+        decoder.decodeImage(rect, ColorFormat.ARGB8888)
+        decoder.decodeImage(0f, 0f, 0.5f, 0.5f, ColorFormat.ARGB8888)
+
+        // Data overloads
+        decoder.decodeImage(data, ColorFormat.ARGB8888)
+        decoder.decodeImage(data, 0, 0, 10, 10, ColorFormat.ARGB8888)
+        decoder.decodeImage(data, rect, ColorFormat.ARGB8888)
+        decoder.decodeImage(data, 0f, 0f, 0.5f, 0.5f, ColorFormat.ARGB8888)
+
+        verify(isolate, Mockito.atLeast(8)).evaluateJavaScriptAsync(any<String>())
+    }
+}

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kOverloadsTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kOverloadsTest.kt
@@ -48,15 +48,6 @@ class Jp2kOverloadsTest {
 
     private val testDispatcher = StandardTestDispatcher()
 
-    class TestListenableFuture<T>(private val result: T) : ListenableFuture<T> {
-        override fun cancel(mayInterruptIfRunning: Boolean) = false
-        override fun isCancelled() = false
-        override fun isDone() = true
-        override fun get() = result
-        override fun get(timeout: Long, unit: TimeUnit?) = result
-        override fun addListener(listener: Runnable, executor: Executor) { listener.run() }
-    }
-
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)

--- a/android/lib/src/test/java/dev/keiji/jp2k/TestUtils.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/TestUtils.kt
@@ -1,0 +1,25 @@
+package dev.keiji.jp2k
+
+import com.google.common.util.concurrent.ListenableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+class TestListenableFuture<T>(private val result: T) : ListenableFuture<T> {
+    override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
+    override fun isCancelled(): Boolean = false
+    override fun isDone(): Boolean = true
+    override fun get(): T = result
+    override fun get(timeout: Long, unit: TimeUnit?): T = result
+    override fun addListener(listener: Runnable, executor: Executor) {
+        listener.run()
+    }
+}
+
+class FailingListenableFuture<T>(private val exception: Throwable) : ListenableFuture<T> {
+    override fun cancel(mayInterruptIfRunning: Boolean) = false
+    override fun isCancelled() = false
+    override fun isDone() = true
+    override fun get(): T { throw java.util.concurrent.ExecutionException(exception) }
+    override fun get(timeout: Long, unit: TimeUnit?): T { throw java.util.concurrent.ExecutionException(exception) }
+    override fun addListener(listener: Runnable, executor: Executor) { listener.run() }
+}


### PR DESCRIPTION
This PR significantly improves the test coverage of the Android library, targeting a goal of >90% (achieved ~86%).

**Key Changes:**
*   **`Jp2kDecoderAsyncCoverageTest.kt`**: Added tests for `init` state transitions (Initialized, Released, Processing), initialization failures (Sandbox/Isolate), `getMemoryUsage`, `validateRatio`, `MIN_INPUT_SIZE`, and concurrent usage scenarios.
*   **`Jp2kDecoderTest.kt`**: Added missing tests for `precache`, `getSize`, and `decodeImage` error paths, including JSON error parsing and exception propagation. Mocked `Log` to support testing with logging enabled.
*   **`Jp2kOverloadsTest.kt`**: New test file verifying that all 14+ overloads of `decodeImage` correctly delegate to the underlying implementation.
*   **`ExceptionTest.kt`**: New test file for `RegionOutOfBoundsException`, `Jp2kError`, and `Jp2kException`.

**Technical Details:**
*   Used `mockito-inline` to mock static methods like `BitmapFactory.decodeByteArray` and `android.util.Log.println`.
*   Utilized `Dispatchers.Unconfined` and `StandardTestDispatcher` to handle Coroutines in unit tests reliably.
*   Addressed compilation issues related to SAM conversions and type inference in Mockito.

**Coverage:**
Final coverage is approximately 86%, with high coverage on critical logic paths.

---
*PR created automatically by Jules for task [15423917814709948555](https://jules.google.com/task/15423917814709948555) started by @keiji*