### PR TITLE
Fix C coverage reporting by using gcov directly

### DIFF
--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -18,9 +18,10 @@ gcc -o test_wrapper_cov test/test_wrapper.c test/stubs.c \
 ./test_wrapper_cov
 
 # Generate coverage report using gcov
-# wrapper.c is included in test_wrapper.c, so we target the object file generated for test_wrapper
+# We target the compiled source file (test/test_wrapper.c) but must explicitly point to the
+# generated data file because GCC prefixes it with the executable name (test_wrapper_cov-test_wrapper.gcda).
 echo "Generating gcov report..."
-gcov_out=$(gcov -b -c -o test_wrapper_cov-test_wrapper.gcda wrapper.c)
+gcov_out=$(gcov -b -c -o test_wrapper_cov-test_wrapper.gcda test/test_wrapper.c)
 
 # Parse output for wrapper.c coverage
 # We exclude "test_wrapper" to avoid matching "test/test_wrapper.c" which also ends in "wrapper.c"

--- a/test/run_coverage.sh
+++ b/test/run_coverage.sh
@@ -2,10 +2,10 @@
 set -e
 
 # Clean previous coverage
-rm -f *.gcda *.gcno coverage.info coverage_summary.txt
+rm -f *.gcda *.gcno coverage.info coverage_summary.txt *.gcov
 
 cleanup() {
-  rm -f test_wrapper_cov *.gcda *.gcno coverage.info
+  rm -f test_wrapper_cov *.gcda *.gcno coverage.info *.gcov
 }
 trap cleanup EXIT
 
@@ -17,15 +17,20 @@ gcc -o test_wrapper_cov test/test_wrapper.c test/stubs.c \
 # Run the test executable
 ./test_wrapper_cov
 
-# Capture coverage (only if lcov is available)
-if command -v lcov >/dev/null 2>&1; then
-    lcov --capture --directory . --output-file coverage.info
-    lcov --extract coverage.info '*/wrapper.c' --output-file coverage_filtered.info
-    lcov --list coverage_filtered.info > coverage_summary.txt
+# Generate coverage report using gcov
+# wrapper.c is included in test_wrapper.c, so we target the object file generated for test_wrapper
+echo "Generating gcov report..."
+gcov_out=$(gcov -b -c -o test_wrapper_cov-test_wrapper.gcda wrapper.c)
+
+# Parse output for wrapper.c coverage
+# We exclude "test_wrapper" to avoid matching "test/test_wrapper.c" which also ends in "wrapper.c"
+echo "$gcov_out" | awk '/File .*wrapper\.c/ && !/test_wrapper/{flag=1; next} /Lines executed:/{if(flag){print $0; flag=0}}' > coverage_summary.txt
+
+# Display summary
+if [ -s coverage_summary.txt ]; then
     cat coverage_summary.txt
 else
-    echo "lcov not found, skipping report generation."
+    echo "Error: Failed to generate coverage summary for wrapper.c"
+    echo "$gcov_out"
+    exit 1
 fi
-
-# Clean up
-# rm -f test_wrapper_cov (handled by trap)


### PR DESCRIPTION
Modified `test/run_coverage.sh` to abandon `lcov` and use `gcov` directly. This resolves incorrect coverage percentages (5.2%) caused by `lcov` misinterpreting source files included in test files (`wrapper.c` in `test_wrapper.c`). The script now correctly targets the generated `.gcda` file and parses `gcov` output to report coverage for `wrapper.c` specifically.

---
*PR created automatically by Jules for task [17646278732811453755](https://jules.google.com/task/17646278732811453755) started by @keiji*