### PR TITLE
Document and implement Float and RectF partial decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,33 @@ val bitmap = decoder.decodeImage(jp2kBytes, 100, 100, 300, 300)
 decoder.precache(jp2kBytes)
 val bitmap = decoder.decodeImage(100, 100, 300, 300)
 
-// Using Rect (Requires precached data)
+// Using Rect
 val rect = Rect(100, 100, 300, 300)
+// With byte array
+val bitmap = decoder.decodeImage(jp2kBytes, rect)
+// Or with precached data
 decoder.precache(jp2kBytes)
 val bitmap = decoder.decodeImage(rect)
+```
+
+#### Ratio-based Partial Decoding
+
+You can also specify the region using ratios (0.0 - 1.0).
+
+```kotlin
+// Decode a region (ratio)
+val bitmap = decoder.decodeImage(jp2kBytes, 0.0f, 0.0f, 0.5f, 0.5f)
+
+// Or using precached data
+decoder.precache(jp2kBytes)
+val bitmap = decoder.decodeImage(0.0f, 0.0f, 0.5f, 0.5f)
+
+// Using RectF
+val rectF = RectF(0.0f, 0.0f, 0.5f, 0.5f)
+// With byte array
+val bitmap = decoder.decodeImage(jp2kBytes, rectF)
+// Or with precached data
+val bitmap = decoder.decodeImage(rectF)
 ```
 
 ## Configuration

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -5,6 +5,7 @@ import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Rect
+import android.graphics.RectF
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.javascriptengine.JavaScriptIsolate
@@ -344,6 +345,22 @@ class Jp2kDecoder(
      * Decodes a specific region of a JPEG 2000 image.
      *
      * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param region The region to decode.
+     * @param colorFormat The desired output color format. Defaults to [ColorFormat.ARGB8888].
+     * @return The decoded [Bitmap].
+     */
+    suspend fun decodeImage(
+        j2kData: ByteArray,
+        region: RectF,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+    ): Bitmap {
+        return decodeImage(j2kData, region.left, region.top, region.right, region.bottom, colorFormat)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image.
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
      * @param left The left coordinate ratio (0.0 - 1.0).
      * @param top The top coordinate ratio (0.0 - 1.0).
      * @param right The right coordinate ratio (0.0 - 1.0).
@@ -423,6 +440,20 @@ class Jp2kDecoder(
      */
     suspend fun decodeImage(
         region: Rect,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+    ): Bitmap {
+        return decodeImage(region.left, region.top, region.right, region.bottom, colorFormat)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image using cached data.
+     *
+     * @param region The region to decode.
+     * @param colorFormat The desired output color format. Defaults to [ColorFormat.ARGB8888].
+     * @return The decoded [Bitmap].
+     */
+    suspend fun decodeImage(
+        region: RectF,
         colorFormat: ColorFormat = ColorFormat.ARGB8888,
     ): Bitmap {
         return decodeImage(region.left, region.top, region.right, region.bottom, colorFormat)

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -5,6 +5,7 @@ import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Rect
+import android.graphics.RectF
 import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.javascriptengine.JavaScriptIsolate
@@ -430,6 +431,34 @@ class Jp2kDecoderAsync(
     /**
      * Decodes a specific region of a JPEG 2000 image asynchronously using cached data.
      *
+     * @param region The region to decode.
+     * @param colorFormat The desired output color format.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        region: RectF,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(region.left, region.top, region.right, region.bottom, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously using cached data with default color format (ARGB 8888).
+     *
+     * @param region The region to decode.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        region: RectF,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(region, ColorFormat.ARGB8888, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously using cached data.
+     *
      * @param left The left coordinate ratio (0.0 - 1.0).
      * @param top The top coordinate ratio (0.0 - 1.0).
      * @param right The right coordinate ratio (0.0 - 1.0).
@@ -584,6 +613,38 @@ class Jp2kDecoderAsync(
     fun decodeImage(
         j2kData: ByteArray,
         region: Rect,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(j2kData, region, ColorFormat.ARGB8888, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously.
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param region The region to decode.
+     * @param colorFormat The desired output color format.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        j2kData: ByteArray,
+        region: RectF,
+        colorFormat: ColorFormat = ColorFormat.ARGB8888,
+        callback: Callback<Bitmap>
+    ) {
+        decodeImage(j2kData, region.left, region.top, region.right, region.bottom, colorFormat, callback)
+    }
+
+    /**
+     * Decodes a specific region of a JPEG 2000 image asynchronously with default color format (ARGB 8888).
+     *
+     * @param j2kData The raw byte array of the JPEG 2000 image.
+     * @param region The region to decode.
+     * @param callback The callback to receive the decoded [Bitmap] or error.
+     */
+    fun decodeImage(
+        j2kData: ByteArray,
+        region: RectF,
         callback: Callback<Bitmap>
     ) {
         decodeImage(j2kData, region, ColorFormat.ARGB8888, callback)

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncCoverageTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncCoverageTest.kt
@@ -5,6 +5,7 @@ import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Rect
+import android.graphics.RectF
 import androidx.javascriptengine.JavaScriptIsolate
 import androidx.javascriptengine.JavaScriptSandbox
 import com.google.common.util.concurrent.ListenableFuture
@@ -192,6 +193,33 @@ class Jp2kDecoderAsyncCoverageTest {
 
         // Exercises: decodeImage(ByteArray, left, top, right, bottom, Callback)
         decoder.decodeImage(data, 0f, 0f, 1f, 1f, callback)
+
+        verify(isolate, Mockito.atLeastOnce()).evaluateJavaScriptAsync(any<String>())
+    }
+
+    @Test
+    fun testDecodeImage_RectF_NoColorFormat() {
+        val decoder = createInitializedDecoder()
+        val callback = org.mockito.kotlin.mock<Callback<Bitmap>>()
+        val data = ByteArray(12)
+        decoder.precache(data, org.mockito.kotlin.mock<Callback<Unit>>())
+        val rectF = RectF(0f, 0f, 0.5f, 0.5f)
+
+        // Exercises: decodeImage(RectF, Callback)
+        decoder.decodeImage(rectF, callback)
+
+        verify(isolate, Mockito.atLeastOnce()).evaluateJavaScriptAsync(any<String>())
+    }
+
+    @Test
+    fun testDecodeImage_ByteArray_RectF_NoColorFormat() {
+        val decoder = createInitializedDecoder()
+        val callback = org.mockito.kotlin.mock<Callback<Bitmap>>()
+        val data = ByteArray(12)
+        val rectF = RectF(0f, 0f, 0.5f, 0.5f)
+
+        // Exercises: decodeImage(ByteArray, RectF, Callback)
+        decoder.decodeImage(data, rectF, callback)
 
         verify(isolate, Mockito.atLeastOnce()).evaluateJavaScriptAsync(any<String>())
     }
@@ -546,6 +574,18 @@ class Jp2kDecoderAsyncCoverageTest {
         val data = ByteArray(20)
 
         decoder.decodeImage(data, -0.1f, 0f, 0.5f, 0.5f, callback)
+        verify(callback).onError(org.mockito.kotlin.check {
+            assertTrue(it is IllegalArgumentException)
+            assertEquals("Ratio must be 0.0 - 1.0", it.message)
+        })
+    }
+
+    @Test
+    fun testDecodeImage_InvalidRatio_Precaching() {
+        val decoder = createInitializedDecoder()
+        val callback = org.mockito.kotlin.mock<Callback<Bitmap>>()
+
+        decoder.decodeImage(-0.1f, 0f, 0.5f, 0.5f, callback)
         verify(callback).onError(org.mockito.kotlin.check {
             assertTrue(it is IllegalArgumentException)
             assertEquals("Ratio must be 0.0 - 1.0", it.message)

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.RectF
 import androidx.javascriptengine.JavaScriptIsolate
 import androidx.javascriptengine.JavaScriptSandbox
 import com.google.common.util.concurrent.ListenableFuture
@@ -498,6 +499,45 @@ class Jp2kDecoderTest {
         decoder.decodeImage(data, rect)
 
         verify(isolate).evaluateJavaScriptAsync(contains("decodeJ2K("))
+    }
+
+    @Test
+    fun testDecodeImage_RectF_Success() = runTest {
+        val jsonBmp = """{"bmp": "AQID", "timePreProcess": 0, "timeWasm": 0, "timePostProcess": 0}"""
+
+        val decoder = createInitializedDecoder { script ->
+            if (script.contains("decodeJ2KWithCacheRatio(")) {
+                TestListenableFuture(jsonBmp)
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+        val data = ByteArray(10)
+        decoder.precache(data)
+
+        val rectF = RectF(0.0f, 0.0f, 0.5f, 0.5f)
+        decoder.decodeImage(rectF)
+
+        verify(isolate).evaluateJavaScriptAsync(contains("decodeJ2KWithCacheRatio("))
+    }
+
+    @Test
+    fun testDecodeImage_ByteArray_RectF_Success() = runTest {
+        val jsonBmp = """{"bmp": "AQID", "timePreProcess": 0, "timeWasm": 0, "timePostProcess": 0}"""
+
+        val decoder = createInitializedDecoder { script ->
+            if (script.contains("decodeJ2KRatio(")) {
+                TestListenableFuture(jsonBmp)
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+
+        val data = ByteArray(20)
+        val rectF = RectF(0.0f, 0.0f, 0.5f, 0.5f)
+        decoder.decodeImage(data, rectF)
+
+        verify(isolate).evaluateJavaScriptAsync(contains("decodeJ2KRatio("))
     }
 
     @Test

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kOverloadsTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kOverloadsTest.kt
@@ -5,6 +5,7 @@ import android.content.res.AssetManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Rect
+import android.graphics.RectF
 import androidx.javascriptengine.JavaScriptIsolate
 import androidx.javascriptengine.JavaScriptSandbox
 import com.google.common.util.concurrent.ListenableFuture
@@ -92,6 +93,7 @@ class Jp2kOverloadsTest {
         val callback = org.mockito.kotlin.mock<Callback<Bitmap>>()
         val data = ByteArray(12)
         val rect = Rect(0, 0, 10, 10)
+        val rectF = RectF(0f, 0f, 0.5f, 0.5f)
 
         // Prepare mock for decode execution
         val jsonBmp = """{"bmp": "AQID"}"""
@@ -105,6 +107,8 @@ class Jp2kOverloadsTest {
         decoder.decodeImage(rect, callback)
         decoder.decodeImage(0f, 0f, 0.5f, 0.5f, ColorFormat.ARGB8888, callback)
         decoder.decodeImage(0f, 0f, 0.5f, 0.5f, callback)
+        decoder.decodeImage(rectF, ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(rectF, callback)
 
         // Data overloads
         decoder.decodeImage(data, ColorFormat.ARGB8888, callback)
@@ -112,11 +116,13 @@ class Jp2kOverloadsTest {
         decoder.decodeImage(data, 0, 0, 10, 10, callback)
         decoder.decodeImage(data, rect, ColorFormat.ARGB8888, callback)
         decoder.decodeImage(data, rect, callback)
+        decoder.decodeImage(data, rectF, ColorFormat.ARGB8888, callback)
+        decoder.decodeImage(data, rectF, callback)
         decoder.decodeImage(data, 0f, 0f, 0.5f, 0.5f, ColorFormat.ARGB8888, callback)
         decoder.decodeImage(data, 0f, 0f, 0.5f, 0.5f, callback)
 
         // Just verify called many times
-        verify(isolate, Mockito.atLeast(14)).evaluateJavaScriptAsync(any<String>())
+        verify(isolate, Mockito.atLeast(18)).evaluateJavaScriptAsync(any<String>())
     }
 
     @Test
@@ -132,6 +138,7 @@ class Jp2kOverloadsTest {
 
         val data = ByteArray(12)
         val rect = Rect(0, 0, 10, 10)
+        val rectF = RectF(0f, 0f, 0.5f, 0.5f)
         val jsonBmp = """{"bmp": "AQID"}"""
         doAnswer { TestListenableFuture(jsonBmp) }.whenever(isolate).evaluateJavaScriptAsync(org.mockito.ArgumentMatchers.contains("decodeJ2K"))
 
@@ -139,14 +146,16 @@ class Jp2kOverloadsTest {
         decoder.decodeImage(ColorFormat.ARGB8888)
         decoder.decodeImage(0, 0, 10, 10, ColorFormat.ARGB8888)
         decoder.decodeImage(rect, ColorFormat.ARGB8888)
+        decoder.decodeImage(rectF, ColorFormat.ARGB8888)
         decoder.decodeImage(0f, 0f, 0.5f, 0.5f, ColorFormat.ARGB8888)
 
         // Data overloads
         decoder.decodeImage(data, ColorFormat.ARGB8888)
         decoder.decodeImage(data, 0, 0, 10, 10, ColorFormat.ARGB8888)
         decoder.decodeImage(data, rect, ColorFormat.ARGB8888)
+        decoder.decodeImage(data, rectF, ColorFormat.ARGB8888)
         decoder.decodeImage(data, 0f, 0f, 0.5f, 0.5f, ColorFormat.ARGB8888)
 
-        verify(isolate, Mockito.atLeast(8)).evaluateJavaScriptAsync(any<String>())
+        verify(isolate, Mockito.atLeast(10)).evaluateJavaScriptAsync(any<String>())
     }
 }


### PR DESCRIPTION
Updated README.md to document partial decoding with Float and RectF.
Implemented missing `RectF` overloads in `Jp2kDecoder` and `Jp2kDecoderAsync`.
Added unit tests for the new overloads.

---
*PR created automatically by Jules for task [16782243766346250002](https://jules.google.com/task/16782243766346250002) started by @keiji*