### PR TITLE
chore: Bump version to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ To install the library, add the dependency to your module's `build.gradle.kts` (
 ### Gradle (Kotlin DSL)
 
 ```kotlin
-implementation("dev.keiji.jp2k:jp2k-decoder-android:0.2.0")
+implementation("dev.keiji.jp2k:jp2k-decoder-android:0.3.0")
 ```
 
 ### Gradle (Groovy DSL)
 
 ```groovy
-implementation 'dev.keiji.jp2k:jp2k-decoder-android:0.2.0'
+implementation 'dev.keiji.jp2k:jp2k-decoder-android:0.3.0'
 ```
 
 ## Usage

--- a/android/lib/build.gradle.kts
+++ b/android/lib/build.gradle.kts
@@ -1,6 +1,6 @@
 import org.gradle.api.publish.maven.MavenPublication
 
-version = "0.2.0"
+version = "0.3.0"
 
 plugins {
     alias(libs.plugins.android.library)


### PR DESCRIPTION
- Updated the library version from "0.2.0" to "0.3.0" in `android/lib/build.gradle.kts`.
- Updated the usage examples in `README.md` to reflect the new version "0.3.0".