### PR TITLE
Add explicit empty-string guard before JSON parsing of JS results

### DIFF
--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -144,10 +144,10 @@ class Jp2kDecoder(
             val resultFuture = isolate.evaluateJavaScriptAsync(script)
             try {
                 val result = resultFuture.await()
-                if (result.isNullOrBlank()) {
-                    throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator")
-                }
                 if (result != INTERNAL_RESULT_SUCCESS) {
+                    if (result.isNullOrBlank()) {
+                        throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator")
+                    }
                     throw IllegalStateException("WASM instantiation failed.")
                 }
             } catch (e: ExecutionException) {
@@ -183,11 +183,11 @@ class Jp2kDecoder(
                 val resultFuture = isolate.evaluateJavaScriptAsync(script)
                 val result = resultFuture.await()
 
-                if (result.isNullOrBlank()) {
-                    throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator or JSON error")
-                }
-
                 if (result != INTERNAL_RESULT_SUCCESS) {
+                    if (result.isNullOrBlank()) {
+                        throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator or JSON error")
+                    }
+
                     val root = JSONObject(result)
                     if (root.has("errorCode")) {
                         val errorCode = root.getInt("errorCode")

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -145,9 +145,7 @@ class Jp2kDecoder(
             try {
                 val result = resultFuture.await()
                 if (result != INTERNAL_RESULT_SUCCESS) {
-                    if (result.isNullOrBlank()) {
-                        throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator")
-                    }
+                    ensureNotEmpty(result, "Success indicator")
                     throw IllegalStateException("WASM instantiation failed.")
                 }
             } catch (e: ExecutionException) {
@@ -184,9 +182,7 @@ class Jp2kDecoder(
                 val result = resultFuture.await()
 
                 if (result != INTERNAL_RESULT_SUCCESS) {
-                    if (result.isNullOrBlank()) {
-                        throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator or JSON error")
-                    }
+                    ensureNotEmpty(result, "Success indicator or JSON error")
 
                     val root = JSONObject(result)
                     if (root.has("errorCode")) {
@@ -242,11 +238,7 @@ class Jp2kDecoder(
 
             val result = withContext(coroutineDispatcher) {
                 val resultFuture = isolate.evaluateJavaScriptAsync(script)
-                val jsonResult = resultFuture.await()
-
-                if (jsonResult.isNullOrBlank()) {
-                    throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
-                }
+                val jsonResult = ensureNotEmpty(resultFuture.await(), "JSON")
 
                 val root = JSONObject(jsonResult)
                 if (root.has("errorCode")) {
@@ -524,11 +516,7 @@ class Jp2kDecoder(
                 val measureTimes = config.logLevel != null
 
                 val resultFuture = isolate.evaluateJavaScriptAsync(script)
-                val jsonResult = resultFuture.await()
-
-                if (jsonResult.isNullOrBlank()) {
-                    throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
-                }
+                val jsonResult = ensureNotEmpty(resultFuture.await(), "JSON")
 
                 val root = JSONObject(jsonResult)
                 if (root.has("errorCode")) {
@@ -606,6 +594,12 @@ class Jp2kDecoder(
         }
     }
 
+    private fun ensureNotEmpty(value: String?, expectedDescription: String): String {
+        if (value.isNullOrBlank()) {
+            throw IllegalStateException("JavaScriptEngine returned empty result - expected $expectedDescription")
+        }
+        return value
+    }
 
     /**
      * Retrieves memory usage statistics from the JS/WASM environment.
@@ -626,11 +620,7 @@ class Jp2kDecoder(
         try {
             return withContext(coroutineDispatcher) {
                 val resultFuture = isolate.evaluateJavaScriptAsync("globalThis.getMemoryUsage()")
-                val jsonResult = resultFuture.await()
-
-                if (jsonResult.isNullOrBlank()) {
-                    throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
-                }
+                val jsonResult = ensureNotEmpty(resultFuture.await(), "JSON")
 
                 val root = JSONObject(jsonResult)
 

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoder.kt
@@ -144,6 +144,9 @@ class Jp2kDecoder(
             val resultFuture = isolate.evaluateJavaScriptAsync(script)
             try {
                 val result = resultFuture.await()
+                if (result.isNullOrBlank()) {
+                    throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator")
+                }
                 if (result != INTERNAL_RESULT_SUCCESS) {
                     throw IllegalStateException("WASM instantiation failed.")
                 }
@@ -179,6 +182,10 @@ class Jp2kDecoder(
 
                 val resultFuture = isolate.evaluateJavaScriptAsync(script)
                 val result = resultFuture.await()
+
+                if (result.isNullOrBlank()) {
+                    throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator or JSON error")
+                }
 
                 if (result != INTERNAL_RESULT_SUCCESS) {
                     val root = JSONObject(result)
@@ -236,7 +243,10 @@ class Jp2kDecoder(
             val result = withContext(coroutineDispatcher) {
                 val resultFuture = isolate.evaluateJavaScriptAsync(script)
                 val jsonResult = resultFuture.await()
-                    ?: throw IllegalStateException("Result Future is null")
+
+                if (jsonResult.isNullOrBlank()) {
+                    throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
+                }
 
                 val root = JSONObject(jsonResult)
                 if (root.has("errorCode")) {
@@ -515,7 +525,10 @@ class Jp2kDecoder(
 
                 val resultFuture = isolate.evaluateJavaScriptAsync(script)
                 val jsonResult = resultFuture.await()
-                    ?: throw IllegalStateException("Result Future is null")
+
+                if (jsonResult.isNullOrBlank()) {
+                    throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
+                }
 
                 val root = JSONObject(jsonResult)
                 if (root.has("errorCode")) {
@@ -613,7 +626,12 @@ class Jp2kDecoder(
         try {
             return withContext(coroutineDispatcher) {
                 val resultFuture = isolate.evaluateJavaScriptAsync("globalThis.getMemoryUsage()")
-                val jsonResult = resultFuture.await() ?: throw IllegalStateException("Result Future is null")
+                val jsonResult = resultFuture.await()
+
+                if (jsonResult.isNullOrBlank()) {
+                    throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
+                }
+
                 val root = JSONObject(jsonResult)
 
                 MemoryUsage(

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -163,10 +163,10 @@ class Jp2kDecoderAsync(
 
         try {
             val result = resultFuture.get()
-            if (result.isNullOrBlank()) {
-                throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator")
-            }
             if (result != INTERNAL_RESULT_SUCCESS) {
+                if (result.isNullOrBlank()) {
+                    throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator")
+                }
                 throw IllegalStateException("WASM instantiation failed.")
             }
         } catch (e: ExecutionException) {
@@ -218,11 +218,11 @@ class Jp2kDecoderAsync(
                     val resultFuture = isolate.evaluateJavaScriptAsync(script)
                     val result = resultFuture.get()
 
-                    if (result.isNullOrBlank()) {
-                        throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator or JSON error")
-                    }
-
                     if (result != INTERNAL_RESULT_SUCCESS) {
+                        if (result.isNullOrBlank()) {
+                            throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator or JSON error")
+                        }
+
                         val root = JSONObject(result)
                         if (root.has("errorCode")) {
                             val errorCode = root.getInt("errorCode")

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -164,9 +164,7 @@ class Jp2kDecoderAsync(
         try {
             val result = resultFuture.get()
             if (result != INTERNAL_RESULT_SUCCESS) {
-                if (result.isNullOrBlank()) {
-                    throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator")
-                }
+                ensureNotEmpty(result, "Success indicator")
                 throw IllegalStateException("WASM instantiation failed.")
             }
         } catch (e: ExecutionException) {
@@ -219,9 +217,7 @@ class Jp2kDecoderAsync(
                     val result = resultFuture.get()
 
                     if (result != INTERNAL_RESULT_SUCCESS) {
-                        if (result.isNullOrBlank()) {
-                            throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator or JSON error")
-                        }
+                        ensureNotEmpty(result, "Success indicator or JSON error")
 
                         val root = JSONObject(result)
                         if (root.has("errorCode")) {
@@ -308,11 +304,7 @@ class Jp2kDecoderAsync(
                     val isolate = checkNotNull(jsIsolate) { "Jp2kDecoder has not been initialized." }
 
                     val resultFuture = isolate.evaluateJavaScriptAsync(script)
-                    val jsonResult = resultFuture.get()
-
-                    if (jsonResult.isNullOrBlank()) {
-                        throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
-                    }
+                    val jsonResult = ensureNotEmpty(resultFuture.get(), "JSON")
 
                     val root = JSONObject(jsonResult)
                     if (root.has("errorCode")) {
@@ -776,11 +768,7 @@ class Jp2kDecoderAsync(
                     val resultFuture = isolate.evaluateJavaScriptAsync(script)
 
                     // Block and wait for result on background thread
-                    val jsonResult = resultFuture.get()
-
-                    if (jsonResult.isNullOrBlank()) {
-                        throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
-                    }
+                    val jsonResult = ensureNotEmpty(resultFuture.get(), "JSON")
 
                     val root = JSONObject(jsonResult)
                     if (root.has("errorCode")) {
@@ -924,11 +912,7 @@ class Jp2kDecoderAsync(
                     val isolate = checkNotNull(jsIsolate) { "Jp2kDecoder has not been initialized." }
                     val resultFuture = isolate.evaluateJavaScriptAsync("globalThis.getMemoryUsage()")
 
-                    val jsonResult = resultFuture.get()
-
-                    if (jsonResult.isNullOrBlank()) {
-                        throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
-                    }
+                    val jsonResult = ensureNotEmpty(resultFuture.get(), "JSON")
 
                     val root = JSONObject(jsonResult)
 
@@ -943,6 +927,13 @@ class Jp2kDecoderAsync(
                 }
             }
         }
+    }
+
+    private fun ensureNotEmpty(value: String?, expectedDescription: String): String {
+        if (value.isNullOrBlank()) {
+            throw IllegalStateException("JavaScriptEngine returned empty result - expected $expectedDescription")
+        }
+        return value
     }
 
     /**

--- a/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
+++ b/android/lib/src/main/java/dev/keiji/jp2k/Jp2kDecoderAsync.kt
@@ -163,6 +163,9 @@ class Jp2kDecoderAsync(
 
         try {
             val result = resultFuture.get()
+            if (result.isNullOrBlank()) {
+                throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator")
+            }
             if (result != INTERNAL_RESULT_SUCCESS) {
                 throw IllegalStateException("WASM instantiation failed.")
             }
@@ -214,6 +217,10 @@ class Jp2kDecoderAsync(
 
                     val resultFuture = isolate.evaluateJavaScriptAsync(script)
                     val result = resultFuture.get()
+
+                    if (result.isNullOrBlank()) {
+                        throw IllegalStateException("JavaScriptEngine returned empty result - expected Success indicator or JSON error")
+                    }
 
                     if (result != INTERNAL_RESULT_SUCCESS) {
                         val root = JSONObject(result)
@@ -301,8 +308,11 @@ class Jp2kDecoderAsync(
                     val isolate = checkNotNull(jsIsolate) { "Jp2kDecoder has not been initialized." }
 
                     val resultFuture = isolate.evaluateJavaScriptAsync(script)
-                    val jsonResult =
-                        resultFuture.get() ?: throw IllegalStateException("Result Future is null")
+                    val jsonResult = resultFuture.get()
+
+                    if (jsonResult.isNullOrBlank()) {
+                        throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
+                    }
 
                     val root = JSONObject(jsonResult)
                     if (root.has("errorCode")) {
@@ -766,8 +776,11 @@ class Jp2kDecoderAsync(
                     val resultFuture = isolate.evaluateJavaScriptAsync(script)
 
                     // Block and wait for result on background thread
-                    val jsonResult =
-                        resultFuture.get() ?: throw IllegalStateException("Result Future is null")
+                    val jsonResult = resultFuture.get()
+
+                    if (jsonResult.isNullOrBlank()) {
+                        throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
+                    }
 
                     val root = JSONObject(jsonResult)
                     if (root.has("errorCode")) {
@@ -911,8 +924,12 @@ class Jp2kDecoderAsync(
                     val isolate = checkNotNull(jsIsolate) { "Jp2kDecoder has not been initialized." }
                     val resultFuture = isolate.evaluateJavaScriptAsync("globalThis.getMemoryUsage()")
 
-                    val jsonResult =
-                        resultFuture.get() ?: throw IllegalStateException("Result Future is null")
+                    val jsonResult = resultFuture.get()
+
+                    if (jsonResult.isNullOrBlank()) {
+                        throw IllegalStateException("JavaScriptEngine returned empty result - expected JSON")
+                    }
+
                     val root = JSONObject(jsonResult)
 
                     val usage = MemoryUsage(

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderAsyncTest.kt
@@ -559,4 +559,98 @@ class Jp2kDecoderAsyncTest {
         verify(isolate).evaluateJavaScriptAsync(contains("decodeJ2KRatio("))
         verify(callback).onSuccess(any())
     }
+
+    @Test
+    fun testLoadWasm_EmptyResult() {
+        doAnswer { invocation ->
+            TestListenableFuture("") // Empty result
+        }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        val directExecutor = Executor { it.run() }
+        val decoder = Jp2kDecoderAsync(backgroundExecutor = directExecutor)
+        val callback = org.mockito.kotlin.mock<Callback<Unit>>()
+        decoder.init(context, callback)
+
+        verify(callback).onError(org.mockito.kotlin.check {
+            assert(it is IllegalStateException)
+            assertEquals("JavaScriptEngine returned empty result - expected Success indicator", it.message)
+        })
+    }
+
+    @Test
+    fun testPrecache_EmptyResult() {
+        val decoder = createInitializedDecoder { script ->
+            if (script.startsWith("globalThis.setData")) {
+                TestListenableFuture("") // Empty result
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+
+        val callback = org.mockito.kotlin.mock<Callback<Unit>>()
+        decoder.precache(ByteArray(10), callback)
+
+        verify(callback).onError(org.mockito.kotlin.check {
+            assert(it is IllegalStateException)
+            assertEquals("JavaScriptEngine returned empty result - expected Success indicator or JSON error", it.message)
+        })
+    }
+
+    @Test
+    fun testGetSize_EmptyResult() {
+        val decoder = createInitializedDecoder { script ->
+            if (script.startsWith("globalThis.getSizeWithCache")) {
+                TestListenableFuture("") // Empty result
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+        decoder.precache(ByteArray(10), org.mockito.kotlin.mock<Callback<Unit>>())
+
+        val callback = org.mockito.kotlin.mock<Callback<Size>>()
+        decoder.getSize(callback)
+
+        verify(callback).onError(org.mockito.kotlin.check {
+            assert(it is IllegalStateException)
+            assertEquals("JavaScriptEngine returned empty result - expected JSON", it.message)
+        })
+    }
+
+    @Test
+    fun testDecodeImage_EmptyResult() {
+        val decoder = createInitializedDecoder { script ->
+            if (script.contains("decodeJ2K(")) {
+                TestListenableFuture("") // Empty result
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+
+        val callback = org.mockito.kotlin.mock<Callback<Bitmap>>()
+        decoder.decodeImage(ByteArray(20), callback)
+
+        verify(callback).onError(org.mockito.kotlin.check {
+            assert(it is IllegalStateException)
+            assertEquals("JavaScriptEngine returned empty result - expected JSON", it.message)
+        })
+    }
+
+    @Test
+    fun testGetMemoryUsage_EmptyResult() {
+        val decoder = createInitializedDecoder { script ->
+            if (script.contains("getMemoryUsage()")) {
+                TestListenableFuture("") // Empty result
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+
+        val callback = org.mockito.kotlin.mock<Callback<MemoryUsage>>()
+        decoder.getMemoryUsage(callback)
+
+        verify(callback).onError(org.mockito.kotlin.check {
+            assert(it is IllegalStateException)
+            assertEquals("JavaScriptEngine returned empty result - expected JSON", it.message)
+        })
+    }
 }

--- a/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
+++ b/android/lib/src/test/java/dev/keiji/jp2k/Jp2kDecoderTest.kt
@@ -741,4 +741,92 @@ class Jp2kDecoderTest {
         }
     }
 
+    @Test
+    fun testLoadWasm_EmptyResult() = runTest {
+        doAnswer { invocation ->
+            TestListenableFuture("") // Empty result
+        }.whenever(isolate).evaluateJavaScriptAsync(any<String>())
+
+        val decoder = Jp2kDecoder(coroutineDispatcher = testDispatcher)
+        try {
+            decoder.init(context)
+            fail("Should throw IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertEquals("JavaScriptEngine returned empty result - expected Success indicator", e.message)
+        }
+    }
+
+    @Test
+    fun testPrecache_EmptyResult() = runTest {
+        val decoder = createInitializedDecoder { script ->
+            if (script.startsWith("globalThis.setData")) {
+                TestListenableFuture("") // Empty result
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+
+        try {
+            decoder.precache(ByteArray(10))
+            fail("Should throw IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertEquals("JavaScriptEngine returned empty result - expected Success indicator or JSON error", e.message)
+        }
+    }
+
+    @Test
+    fun testGetSize_EmptyResult() = runTest {
+        val decoder = createInitializedDecoder { script ->
+            if (script.startsWith("globalThis.getSizeWithCache")) {
+                TestListenableFuture("") // Empty result
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+        decoder.precache(ByteArray(10))
+
+        try {
+            decoder.getSize()
+            fail("Should throw IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertEquals("JavaScriptEngine returned empty result - expected JSON", e.message)
+        }
+    }
+
+    @Test
+    fun testDecodeImage_EmptyResult() = runTest {
+        val decoder = createInitializedDecoder { script ->
+            if (script.contains("decodeJ2K(")) {
+                TestListenableFuture("") // Empty result
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+
+        val data = ByteArray(20)
+        try {
+            decoder.decodeImage(data)
+            fail("Should throw IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertEquals("JavaScriptEngine returned empty result - expected JSON", e.message)
+        }
+    }
+
+    @Test
+    fun testGetMemoryUsage_EmptyResult() = runTest {
+        val decoder = createInitializedDecoder { script ->
+            if (script.contains("getMemoryUsage()")) {
+                TestListenableFuture("") // Empty result
+            } else {
+                TestListenableFuture(INTERNAL_RESULT_SUCCESS)
+            }
+        }
+
+        try {
+            decoder.getMemoryUsage()
+            fail("Should throw IllegalStateException")
+        } catch (e: IllegalStateException) {
+            assertEquals("JavaScriptEngine returned empty result - expected JSON", e.message)
+        }
+    }
 }


### PR DESCRIPTION
This change adds explicit empty/blank string checks for results returned from the JavaScript engine before they are processed or parsed as JSON. This addresses a behavior in the Jetpack JavaScriptEngine where non-string expression results are silently coerced to an empty string, which previously caused confusing JSONException errors.

Key improvements:
- More descriptive error messages when the JS engine returns an empty result.
- Explicit validation of WASM instantiation and data setting success indicators.
- Added unit tests covering empty result scenarios for all JS-interacting methods in both Jp2kDecoder and Jp2kDecoderAsync.

Fixes #132

---
*PR created automatically by Jules for task [463474083085065148](https://jules.google.com/task/463474083085065148) started by @keiji*